### PR TITLE
Elimination of duplicate content

### DIFF
--- a/courses/courses.yml
+++ b/courses/courses.yml
@@ -1,6 +1,9 @@
-- name: Začátečnický kurz Pyladies
-  description: Naučte se Python vážně od začátku. Žádné předchozí znalosti nejsou potřeba.
+pyladies:
   link: pyladies
-- name: MI-PYT
-  description: Základy již znáte a chcete se dozvědět o dalších možnostech využití Pythonu.
+  title: Začátečnický kurz Pyladies
+  description: Naučte se Python vážně od začátku. Žádné předchozí znalosti nejsou potřeba.
+
+mi-pyt:
   link: mi-pyt
+  title: MI-PYT
+  description: Základy již znáte a chcete se dozvědět o dalších možnostech využití Pythonu.

--- a/courses/index.html
+++ b/courses/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Seznam online kurzů Pythonu{% endblock %}
-
 {% block content %}
     <p>Momentálně jsou dostupné tyto kurzy:</p>
 
@@ -10,16 +8,8 @@
             <div class="sections col-xs-12 col-sm-12 col-md-8 col-lg-8">
                 {% for course in courses %}
                 <div class="section-box" id="section{{ loop.index }}">
-                    {% if 'link' in course %}
-                        <h4><a href="{{ course_url(course['link']) }}">{{ course['name'] }}</a></h4>
-                    {% else %}
-                        {{ course['name'] }}
-                    {% endif %}
-
-                    {% if 'description' in course %}
-                        <p class="section-info course-city-p"> {{ course['description'] }} </p>
-                    {% endif %}
-
+                    <h4><a href="{{ course_url(courses[course]['link']) }}">{{ courses[course]['title'] }}</a></h4>
+                    <p class="section-info course-city-p"> {{ courses[course]['description'] }} </p>
                 </div>
                 {% endfor %}
             </div>

--- a/courses/mi-pyt/12-micropython/info.yml
+++ b/courses/mi-pyt/12-micropython/info.yml
@@ -1,3 +1,3 @@
 course: MI-PYT
-title: MictoPython
+title: MicroPython
 style: md

--- a/courses/mi-pyt/index.html
+++ b/courses/mi-pyt/index.html
@@ -1,32 +1,11 @@
-{% extends 'templates/_base.html' %}
+{% extends 'templates/course_page.html' %}
 
 {% block title %}MI-PYT kurz{% endblock %}
 
-{% block content %}
+{% block headline %}
 
     <h2>Kurz MI-PYT</h2>
     <p>Díváte se na materiály předmětu MI-PYT (Pokročilý Python) na FIT ČVUT. Materiály jsou dostupné v dvojí podobě, interně pro studenty FITu na Eduxu a pro všechny veřejně na <a href="https://github.com/cvut/MI-PYT" alt="GitHub">GitHubu</a>.</p>
     <p>Kde není uvedeno jinak, jsou materiály dostupné pod licencí Creative Commons Attribution-ShareAlike 4.0 International, kde autorem je Petr Viktorin a Miro Hrončok (vyučující předmětu) a další přispěvatelé. Tento kurz vzniká pod záštitou firmy Red Hat Czech, s.r.o.</p>
-
-    <!-- Course description -->
-    <section class="course-city container">
-        <div class="row">
-            <div class="sections col-xs-12 col-sm-12 col-md-8 col-lg-8">
-                {% for lesson in plan %}
-                <div class="section-box" id="section{{ loop.index }}">
-                    <h4 class="section-heading">
-                        {{ lesson['name'] }}
-                    </h4>
-                    {% for mat in lesson['materials'] %}
-                        <div class="section-info">
-                            <span class="glyphicon {{ 'glyphicon-pencil' }} section-icon"></span>
-                            <a href="{{ lesson_url(names.get(mat['link'])[0], mat['link'].split('/')[-1]) }}">{{ names.get(mat['link'])[1] }}</a>
-                        </div>
-                    {% endfor %}
-                </div>
-                {% endfor %}
-            </div>
-        </div>
-    </section>
     
-{% endblock content %}
+{% endblock headline %}

--- a/courses/mi-pyt/index.html
+++ b/courses/mi-pyt/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/course_page.html' %}
 
-{% block title %}MI-PYT kurz{% endblock %}
-
 {% block headline %}
 
     <h2>Kurz MI-PYT</h2>

--- a/courses/pyladies/and-or/index.html
+++ b/courses/pyladies/and-or/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Nebo anebo a{% endblock %}
-
 {% block content %}
             <div class="row stuff">
                 <div class="col-lg-12">

--- a/courses/pyladies/asteroids/index.html
+++ b/courses/pyladies/asteroids/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Asteroids{% endblock %}
-
 {% block content %}
 
 <div class="row stuff">

--- a/courses/pyladies/branching/index.html
+++ b/courses/pyladies/branching/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Větvení v Gitu{% endblock %}
-
 {% block style %}
 .green  {   color:  #0A3;    }
 .red    {   color:  #D30;    }

--- a/courses/pyladies/circular_imports/index.html
+++ b/courses/pyladies/circular_imports/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Poznámka k importu{% endblock %}
-
 {% block content %}
 
 <div class="slides row stuff">

--- a/courses/pyladies/classes/index.html
+++ b/courses/pyladies/classes/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Třídy{% endblock %}
-
 {% block content %}
 
 <div class="row stuff">

--- a/courses/pyladies/cmdline/index.html
+++ b/courses/pyladies/cmdline/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Příkazová řádka{% endblock %}
-
 {% block content %}
             <div class="slides">
                 <section class="row stuff">

--- a/courses/pyladies/comparisons/index.html
+++ b/courses/pyladies/comparisons/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Porovnávání{% endblock %}
-
 {% block content %}
             <div class="row stuff">
                 <div class="col-lg-12">

--- a/courses/pyladies/cooperation_and_OSS/index.html
+++ b/courses/pyladies/cooperation_and_OSS/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Spolupráce a Open source{% endblock %}
-
 {% block content %}
 
 <div class="slides row stuff">

--- a/courses/pyladies/dicts/index.html
+++ b/courses/pyladies/dicts/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Slovníky{% endblock %}
-
 {% block content %}
 
 <div class="row stuff">

--- a/courses/pyladies/exceptions/index.html
+++ b/courses/pyladies/exceptions/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Výjimky{% endblock %}
-
 {% block style %}
 .err-lineno {
     display: inline-block;

--- a/courses/pyladies/files/index.html
+++ b/courses/pyladies/files/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Soubory{% endblock %}
-
 {% block content %}
 
 <div class="slides row stuff">

--- a/courses/pyladies/functions/index.html
+++ b/courses/pyladies/functions/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Funkce{% endblock %}
-
 {% block content %}            
             <div class="slides row stuff">
                 <section class="col-lg-12">

--- a/courses/pyladies/git/index.html
+++ b/courses/pyladies/git/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Git{% endblock %}
-
 {% block style %}
 .green  {   color:  #0A3;    }
 .red    {   color:  #D30;    }

--- a/courses/pyladies/github-api/index.html
+++ b/courses/pyladies/github-api/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Github API{% endblock %}
-
 {% block content %}
 
 <div class="row stuff">

--- a/courses/pyladies/hello-world/index.html
+++ b/courses/pyladies/hello-world/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}První program{% endblock %}
-
 {% block style %}
 .example-command {
     text-align: center;

--- a/courses/pyladies/index.html
+++ b/courses/pyladies/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/course_page.html' %}
 
-{% block title %}Začátečnický kurz PyLadies{% endblock %}
-
 {% block headline %}
 
     <h2>Začátečnický kurz PyLadies</h2>

--- a/courses/pyladies/index.html
+++ b/courses/pyladies/index.html
@@ -1,32 +1,11 @@
-{% extends 'templates/_base.html' %}
+{% extends 'templates/course_page.html' %}
 
 {% block title %}Začátečnický kurz PyLadies{% endblock %}
 
-{% block content %}
+{% block headline %}
 
     <h2>Začátečnický kurz PyLadies</h2>
     <p><a href="http://pyladies.cz/" alt="Pyladies"> Pyladies</a> jsou (mezinárodní) aktivita, která se snaží přiblížit IT ženám a ženy k IT. K tomuto účelu využívá programovací jazyk Python. Zde najdeš materiály, které se používají na začátečnických kurzech v Praze, Brně a Ostravě.</p>
     <p>Jednotlivé lekce jsou určeny naprostým začátečníkům, žádné předchozí znalosti nejsou nutné. Instrukce jsou uvedeny pro operační systémy Linux, Windows i macOS.</p>
 
-    <!-- Course description -->
-    <section class="course-city container">
-        <div class="row">
-            <div class="sections col-xs-12 col-sm-12 col-md-8 col-lg-8">
-                {% for lesson in plan %}
-                <div class="section-box" id="section{{ loop.index }}">
-                    <h4 class="section-heading">
-                        {{ lesson['name'] }}
-                    </h4>
-                    {% for mat in lesson['materials'] %}
-                        <div class="section-info">
-                            <span class="glyphicon {{ 'glyphicon-pencil' }} section-icon"></span>
-                            <a href="{{ lesson_url(names.get(mat['link'])[0], mat['link'].split('/')[-1]) }}">{{ names.get(mat['link'])[1] }}</a>
-                        </div>
-                    {% endfor %}
-                </div>
-                {% endfor %}
-            </div>
-        </div>
-    </section>
-    
-{% endblock content %}
+{% endblock headline %}

--- a/courses/pyladies/inheritance/index.html
+++ b/courses/pyladies/inheritance/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Dědičnost{% endblock %}
-
 {% block style %}
 .changed {
     background-color: #eef560;

--- a/courses/pyladies/install/index.html
+++ b/courses/pyladies/install/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Instalace{% endblock %}
-
 {% block content %}
             <div class="row stuff">
                 <div class="col-lg-12">

--- a/courses/pyladies/install_editor/index.html
+++ b/courses/pyladies/install_editor/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Nastavení editoru{% endblock %}
-
 {% block content %}
             <div class="row stuff">
                 <div class="col-lg-12">

--- a/courses/pyladies/install_git/index.html
+++ b/courses/pyladies/install_git/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Instalace gitu{% endblock %}
-
 {% block content %}
 
             <div class="row stuff">

--- a/courses/pyladies/json/index.html
+++ b/courses/pyladies/json/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}JSON{% endblock %}
-
 {% block content %}
 
 <div class="row stuff">

--- a/courses/pyladies/lists/index.html
+++ b/courses/pyladies/lists/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Seznamy{% endblock %}
-
 {% block content %}
 
 <div class="slides row stuff">

--- a/courses/pyladies/modules/index.html
+++ b/courses/pyladies/modules/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Moduly{% endblock %}
-
 {% block content %}
 
 <div class="slides row stuff">

--- a/courses/pyladies/own_functions/index.html
+++ b/courses/pyladies/own_functions/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Vlastní funkce{% endblock %}
-
 {% block content %}
 
 <div class="slides row stuff">

--- a/courses/pyladies/pong/index.html
+++ b/courses/pyladies/pong/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Pong{% endblock %}
-
 {% block content %}
 
 <div class="row stuff">

--- a/courses/pyladies/printing/index.html
+++ b/courses/pyladies/printing/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Chybové hlášky a print{% endblock %}
-
 {% block style %}
     .err-lineno {
         display: inline-block;

--- a/courses/pyladies/pyglet/index.html
+++ b/courses/pyladies/pyglet/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Grafika{% endblock %}
-
 {% block content %}
 
 <div class="row stuff">

--- a/courses/pyladies/strings/index.html
+++ b/courses/pyladies/strings/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Řetězce{% endblock %}
-
 {% block content %}
 
             <div class="slides row stuff">

--- a/courses/pyladies/testing/index.html
+++ b/courses/pyladies/testing/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Testování{% endblock %}
-
 {% block content %}
 
 <div class="slides row stuff">

--- a/courses/pyladies/tuples/index.html
+++ b/courses/pyladies/tuples/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}N-tice{% endblock %}
-
 {% block content %}
 
 <div class="slides row stuff">

--- a/courses/pyladies/turtle/index.html
+++ b/courses/pyladies/turtle/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Želva a cykly{% endblock %}
-
 {% block content %}
 
             <div class="slides row stuff">

--- a/courses/pyladies/variables/index.html
+++ b/courses/pyladies/variables/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Proměnné{% endblock %}
-
 {% block style %}
             .extra { background-color: #f8f8f8; margin: -10px -1000px; padding: 10px 1000px; }
 {% endblock %}

--- a/courses/pyladies/while/index.html
+++ b/courses/pyladies/while/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Cyklus While{% endblock %}
-
 {% block content %}
 
             <div class="slides row stuff">

--- a/naucse/routes.py
+++ b/naucse/routes.py
@@ -36,7 +36,7 @@ def about():
 # Page with listed online courses.
 @app.route('/courses/')
 def courses():
-    return render_template("courses/index.html", courses=read_yaml("courses/courses.yml"))
+    return render_template("courses/index.html", courses=read_yaml("courses/courses.yml"), title="Seznam online kurzů Pythonu")
 
 
 # Course page.
@@ -44,6 +44,7 @@ def courses():
 def course_page(course):
     template = 'courses/{}/index.html'.format(course)
     plan = read_yaml("courses/" + course + "/plan.yml")
+    title = (read_yaml("courses/courses.yml"))[course]['title']
 
     lesson_dict = {}
 
@@ -60,7 +61,7 @@ def course_page(course):
             lesson_dict[mat['link']] = (the_course, info_file['title'])
 
     try:
-        return render_template(template, plan=read_yaml("courses/" + course + "/plan.yml"), names=lesson_dict)
+        return render_template(template, plan=read_yaml("courses/" + course + "/plan.yml"), names=lesson_dict, title=title)
     except TemplateNotFound:
         abort(404)
 
@@ -93,7 +94,7 @@ def course_lesson(course, lesson, page):
         elif info['style'] == "ipynb":
             return render_template('templates/ipython_page.html', static=lesson_static_url, lesson=lesson_url, title=title, content=content)
         else:
-            return render_template(template, static=lesson_static_url, lesson=lesson_url)
+            return render_template(template, static=lesson_static_url, lesson=lesson_url, title=title)
     except TemplateNotFound:
         abort(404)
 

--- a/naucse/templates/_base.html
+++ b/naucse/templates/_base.html
@@ -2,7 +2,14 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <title>{% block title %}{% endblock %} - Nauč se Python</title>
+        <title>
+        {% if title is defined %}
+            {{ title }}
+        {% else %}
+            Nauč se Python
+        {% endif %}
+
+        </title>
         <link rel="stylesheet" href="{{url_for('static', filename='css/bootstrap.css')}}">
         <link rel="stylesheet" href="{{url_for('static', filename='css/nausce.css')}}">
 

--- a/naucse/templates/_base.html
+++ b/naucse/templates/_base.html
@@ -5,7 +5,7 @@
         <title>{% block title %}{% endblock %} - Nauč se Python</title>
         <link rel="stylesheet" href="{{url_for('static', filename='css/bootstrap.css')}}">
         <link rel="stylesheet" href="{{url_for('static', filename='css/nausce.css')}}">
-        
+
         <style>
            	{% block style %}
             {% endblock %}
@@ -16,11 +16,11 @@
             <div class="header">
                 <h1>Nauč se Python</h1>
             </div>
-            
+
             <div style="border: 3px solid red; padding: 10px 10px 0px 10px">
                 <p>Tato stránka je momentálně v rekonstrukci. Využijte raději <a href="http://pyladies.cz/brno/"> studijní materiály</a> k začátečnickému kurzu PyLadies. Pokud se chcete podílet na vylepšení těchto stránek, navštivte <a href="https://github.com/pyvec/naucse.python.cz">repozitář na GitHubu</a>.</p>
             </div>
-            
+
             <div>
                	{% block content %}
                 {% endblock %}
@@ -29,9 +29,9 @@
                 <div>Licence: <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International</a></div>
                 <div>Upravit stránky: <a href="https://github.com/pyvec/naucse.python.cz">GitHub</a></div>
             </div>
-            
+
             <script type="text/javascript" src="{{ url_for('static', filename='js/solutions.js') }}"></script>
-            
+
         </div>
     </body>
 </html>

--- a/naucse/templates/about.html
+++ b/naucse/templates/about.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Nauč se Python{% endblock %}
-
 {% block content %}
 
 {% filter markdown %}

--- a/naucse/templates/course_page.html
+++ b/naucse/templates/course_page.html
@@ -5,7 +5,6 @@
     {% block headline %}
     {% endblock headline %}
 
-    <!-- Course description -->
     <section class="course-city container">
         <div class="row">
             <div class="sections col-xs-12 col-sm-12 col-md-8 col-lg-8">
@@ -25,5 +24,5 @@
             </div>
         </div>
     </section>
-    
+
 {% endblock content %}

--- a/naucse/templates/course_page.html
+++ b/naucse/templates/course_page.html
@@ -1,0 +1,29 @@
+{% extends 'templates/_base.html' %}
+
+{% block content %}
+
+    {% block headline %}
+    {% endblock headline %}
+
+    <!-- Course description -->
+    <section class="course-city container">
+        <div class="row">
+            <div class="sections col-xs-12 col-sm-12 col-md-8 col-lg-8">
+                {% for lesson in plan %}
+                <div class="section-box" id="section{{ loop.index }}">
+                    <h4 class="section-heading">
+                        {{ lesson['name'] }}
+                    </h4>
+                    {% for mat in lesson['materials'] %}
+                        <div class="section-info">
+                            <span class="glyphicon {{ 'glyphicon-pencil' }} section-icon"></span>
+                            <a href="{{ lesson_url(names.get(mat['link'])[0], mat['link'].split('/')[-1]) }}">{{ names.get(mat['link'])[1] }}</a>
+                        </div>
+                    {% endfor %}
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </section>
+    
+{% endblock content %}

--- a/naucse/templates/index.html
+++ b/naucse/templates/index.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %}Úvodní stránka{% endblock %}
-
 {% block content %}
     <p>Vítejte na naucse.python.cz</p>
     <a href="{{ url_for('about') }}">INFO</a></BR>

--- a/naucse/templates/ipython_page.html
+++ b/naucse/templates/ipython_page.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %} {{ title }} {% endblock %}
-
 {% block content %}
 
 {% filter ipython %} {{ content }} {% endfilter %}

--- a/naucse/templates/markdown_page.html
+++ b/naucse/templates/markdown_page.html
@@ -1,7 +1,5 @@
 {% extends 'templates/_base.html' %}
 
-{% block title %} {{ title }} {% endblock %}
-
 {% block content %}
 
 {% filter markdown %} {{ content }} {% endfilter %}


### PR DESCRIPTION
Společný obsah kurzů byl přesunut do jedné šablony. Titulky jednotlivých stránek se berou z yml šablon nebo se jako výchozí použije pouze _Nauč se Python_.

This fixes #25 