### PR TITLE
Hide navigation texts on small devices

### DIFF
--- a/naucse/templates/lesson.html
+++ b/naucse/templates/lesson.html
@@ -28,13 +28,15 @@
         <div class="row prev-next">
             {% if prv %}
                 <div class="col text-left">
-                    <a href="{{ lesson_url(prv.lesson, page=prv.slug) }}">← {{ prv.title }}</a>
+                    <a href="{{ lesson_url(prv.lesson, page=prv.slug) }}" class="hidden-xs-down">← {{ prv.title }}</a>
+                    <a href="{{ lesson_url(prv.lesson, page=prv.slug) }}" class="hidden-sm-up">←</a>
                 </div>
             {% endif %}
 
             {% if nxt %}
                 <div class="col text-right">
-                    <a href="{{ lesson_url(nxt.lesson, page=nxt.slug) }}">{{ nxt.title }} →</a>
+                    <a href="{{ lesson_url(nxt.lesson, page=nxt.slug) }}" class="hidden-xs-down">{{ nxt.title }} →</a>
+                    <a href="{{ lesson_url(nxt.lesson, page=nxt.slug) }}" class="hidden-sm-up">→</a>
                 </div>
             {% endif %}
         </div>

--- a/naucse/templates/lesson.html
+++ b/naucse/templates/lesson.html
@@ -28,15 +28,13 @@
         <div class="row prev-next">
             {% if prv %}
                 <div class="col text-left">
-                    <a href="{{ lesson_url(prv.lesson, page=prv.slug) }}" class="hidden-xs-down">← {{ prv.title }}</a>
-                    <a href="{{ lesson_url(prv.lesson, page=prv.slug) }}" class="hidden-sm-up">←</a>
+                    <a href="{{ lesson_url(prv.lesson, page=prv.slug) }}">← <span class="hidden-xs-down">{{ prv.title }}</span></a>
                 </div>
             {% endif %}
 
             {% if nxt %}
                 <div class="col text-right">
-                    <a href="{{ lesson_url(nxt.lesson, page=nxt.slug) }}" class="hidden-xs-down">{{ nxt.title }} →</a>
-                    <a href="{{ lesson_url(nxt.lesson, page=nxt.slug) }}" class="hidden-sm-up">→</a>
+                    <a href="{{ lesson_url(nxt.lesson, page=nxt.slug) }}"><span class="hidden-xs-down">{{ nxt.title }}</span> →</a>
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
Display only arrows at the end of the lesson on small screens.