### PR TITLE
Automatically convert static/.. links to static() call

### DIFF
--- a/lessons/git/git-collaboration-2in1/index.md
+++ b/lessons/git/git-collaboration-2in1/index.md
@@ -102,7 +102,7 @@ Další kopie na GitHubu je "vaše" a můžete si do ní nahrát cokoliv
 (nejčastěji se v ní ale zveřejňují změny, které můžou být užitečné pro ostatní). 
 A třetí kopii repozitáře máte u sebe na počítači. 
 
-![Git workflow]({{ static('gh-workflow-diagram.svg') }})
+![Git workflow](static/gh-workflow-diagram.svg)
 
 ### Práce s lokálním repozitářem
 
@@ -192,7 +192,7 @@ Pak soubor uložíme a zavřeme editor.
 
 Pro lepší pochopení, co dělají jednotlivé příkazy, a v jakém stavu můžou být soubory/změny, přikládáme tento diagram: 
 
-![Git workflow]({{ static('diagram.png') }})
+![Git workflow](static/diagram.png)
 
 #### Log (`git log`)
 Teď, když za sebou máme první revizi, podívejme se, jak vypadá historie repozitáře, do kterého chceme přispívat.

--- a/lessons/intro/async/index.md
+++ b/lessons/intro/async/index.md
@@ -1114,7 +1114,7 @@ Do vizualizátoru bludiště doplňte funkcionalitu hry. V režimu hry:
 
 Máte k dispozici základní třídu `Actor`, která reprezentuje aktora (postavu v bludišti):
 
- * [class Actor]({{ static('actor.py') }})
+ * [class Actor](static/actor.py)
 
 Tato třída definuje rozhraní jednotlivých postav a zároveň implementuje základní chování postavy - jde nejkratší cestou k cíli rychlostí jedno políčko za sekundu.
 Aby to mohlo fungovat, musí kód, který postavu používá:

--- a/lessons/intro/numpy/index.ipynb
+++ b/lessons/intro/numpy/index.ipynb
@@ -52,11 +52,11 @@
    "source": [
     "Mezitím co se to bude instalovat si stáhněte do adresáře pro dnešní cvičení tyto soubory:\n",
     "\n",
-    "* [matrixdemo.py]({{ static('matrixdemo.py') }})\n",
-    "* [python.jpg]({{ static('python.jpg') }})\n",
-    "* [sample.wav]({{ static('sample.wav') }})\n",
-    "* [secret.png]({{ static('secret.png') }})\n",
-    "* [python-logo-template.svg]({{ static('python-logo-template.svg') }})\n",
+    "* [matrixdemo.py](static/matrixdemo.py)\n",
+    "* [python.jpg](static/python.jpg)\n",
+    "* [sample.wav](static/sample.wav)\n",
+    "* [secret.png](static/secret.png)\n",
+    "* [python-logo-template.svg](static/python-logo-template.svg)\n",
     "\n",
     "A až bude nainstalováno, spusťte si v tomto adresáři nový Notebook."
    ]

--- a/lessons/intro/pandas/index.ipynb
+++ b/lessons/intro/pandas/index.ipynb
@@ -238,9 +238,9 @@
    "metadata": {},
    "source": [
     "Po importu si ještě stáhněte do svého pracovního adresáře tři potřebné soubory:\n",
-    "[actors.csv]({{ static('actors.csv') }}),\n",
-    "[spouses.csv]({{ static('spouses.csv') }}), a\n",
-    "[style-table.css]({{ static('style-table.css') }})."
+    "[actors.csv](static/actors.csv),\n",
+    "[spouses.csv](static/spouses.csv), a\n",
+    "[style-table.css](static/style-table.css)."
    ]
   },
   {

--- a/lessons/intro/pyqt/index.md
+++ b/lessons/intro/pyqt/index.md
@@ -490,8 +490,8 @@ A poté je na správných místech vyrendrujeme:
                     SVG_WALL.render(painter, rect)
 ```
 
-* [grass.svg]({{ static('pics/grass.svg') }})
-* [wall.svg]({{ static('pics/wall.svg') }})
+* [grass.svg](static/pics/grass.svg)
+* [wall.svg](static/pics/wall.svg)
 
 
 Model/View
@@ -840,7 +840,7 @@ Zobrazování cesty
     * matici šipek máte opět z úloh z minula, stačí je zobrazit pouze tam, kde jsou čáry
 * od některých postav logicky cesta k cíli nemusí existovat, od nich tedy žádnou nevykreslujte (aplikace s takovou situací musí počítat a nesmí spadnout)
 
-![Obrázek bludiště]({{ static('mazepic.png') }})
+![Obrázek bludiště](static/mazepic.png)
 
 Odevzdání
 ---------

--- a/lessons/intro/turtle/index.md
+++ b/lessons/intro/turtle/index.md
@@ -93,7 +93,7 @@ obrázky:
 
 Nakresli čtverec.
 
-![Želví čtverec]({{ static('turtle-square.png') }})
+![Želví čtverec](static/turtle-square.png)
 
 Čtverec má čtyři rovné strany,
 a čtyři rohy po 90°.
@@ -121,7 +121,7 @@ Nakresli obdélník.
 
 Zkus zařídit, aby se po nakreslení „dívala” želva doprava (tak jako na začátku).
 
-![Želví obdélník]({{ static('turtle-rect.png') }})
+![Želví obdélník](static/turtle-rect.png)
 
 {% filter solution %}
 ```python
@@ -144,7 +144,7 @@ exitonclick()
 
 Nakresli tři čtverce, každý otočený třeba o 20°.
 
-![Tři želví čtverce]({{ static('turtle-squares.png') }})
+![Tři želví čtverce](static/turtle-squares.png)
 
 {% filter solution %}
 ```python
@@ -252,7 +252,7 @@ Nakresli čtverec.
 V programu použij `forward` jen dvakrát:
 jednou v importu, jednou jako volání.
 
-![Želví čtverec]({{ static('turtle-square.png') }})
+![Želví čtverec](static/turtle-square.png)
 
 {% filter solution %}
 ```python
@@ -274,7 +274,7 @@ aby přestala, resp. začala kreslit.
 
 Zkus nakreslit přerušovanou čáru.
 
-![Želva a přerušovaná čára]({{ static('turtle-dashed.png') }})
+![Želva a přerušovaná čára](static/turtle-dashed.png)
 
 {% filter solution %}
 ```python
@@ -293,7 +293,7 @@ exitonclick()
 Pak zkus zařídit, aby jednotlivé čárky byly postupně
 větší a větší.
 
-![Želva a přerušovaná čára]({{ static('turtle-dashed2.png') }})
+![Želva a přerušovaná čára](static/turtle-dashed2.png)
 
 !!! note "Nápověda"
 
@@ -320,7 +320,7 @@ Nakonec nakresli 3 čtverce, každý otočený o 20°.
 Tentokrát už víš, jak to dělat chytře: opakuj pomocí příkazu
 `for`, ne kopírováním kódu.
 
-![Tři želví čtverce]({{ static('turtle-squares.png') }})
+![Tři želví čtverce](static/turtle-squares.png)
 
 {% filter solution %}
 ```python
@@ -341,8 +341,8 @@ exitonclick()
 
 Máš-li hotovo, zkus nakreslit schody:
 
-![Želví schody]({{ static('turtle-stairs.png') }})
+![Želví schody](static/turtle-stairs.png)
 
 A máš-li i schody, zkus nakreslit těchto šest (nebo sedm?) šestiúhelníků:
 
-![Želví plástev]({{ static('turtle-hexagons.png') }})
+![Želví plástev](static/turtle-hexagons.png)

--- a/lessons/micropython/mini-workshop/organizers.md
+++ b/lessons/micropython/mini-workshop/organizers.md
@@ -163,6 +163,6 @@ Nakonec na NodeMCU stiskneme tlačítko RST, a pak nahrajeme `boot.py`:
 [Fedora]: https://getfedora.org/
 [gedit-setup]: {{ lesson_url('beginners/install-editor', page='gedit') }}
 [micropython]: https://micropython.org/download#esp8266
-[boot.py]: {{ static('boot.py') }}
+[boot.py]: static/boot.py
 [esptool]: https://github.com/espressif/esptool
 [ampy]: https://github.com/adafruit/ampy

--- a/naucse/models.py
+++ b/naucse/models.py
@@ -145,10 +145,16 @@ class Page(Model):
             with self.path.open() as file:
                 content = file.read()
 
+        def convert_url(url):
+            prefix = 'static/'
+            if not url.startswith(prefix):
+                return url
+            return static_url(url[len(prefix):])
+
         if self.style == 'md':
-            content = jinja2.Markup(convert_markdown(content))
+            content = jinja2.Markup(convert_markdown(content, convert_url))
         elif self.style == 'ipynb':
-            content = jinja2.Markup(convert_notebook(content))
+            content = jinja2.Markup(convert_notebook(content, convert_url))
         else:
             template = self._get_template()
             content = jinja2.Markup(content)

--- a/test_naucse/test_markdown.py
+++ b/test_naucse/test_markdown.py
@@ -1,5 +1,7 @@
 from textwrap import dedent
 
+import pytest
+
 from naucse.markdown_util import convert_markdown
 
 
@@ -126,3 +128,16 @@ def test_markdown_ansi_colors():
 def test_markdown_keeps_nbsp():
     text = 'Some text\N{NO-BREAK SPACE}more text'
     assert convert_markdown(text).strip() == '<p>{}</p>'.format(text)
+
+
+@pytest.mark.parametrize('what', ('image', 'link'))
+def test_static_link_conversion(what):
+    text = '[alt](foo/bar)'
+    if what == 'image':
+        text = '!' + text
+
+    def convert_url(url):
+        return url[::-1]
+
+    param = 'href' if what == 'link' else 'src'
+    assert '{}="rab/oof"'.format(param) in convert_markdown(text, convert_url)


### PR DESCRIPTION
Fixes https://github.com/pyvec/naucse.python.cz/issues/93

Introcudes a new "context" dictionary that can be passed to
`convert_markdown()` or `convert_notebook()`.

The conversion only works for Markdown-done images and links,
i.e. it cannot work in HTML documents, calls to other functions
such as `figure(img=static/...)`, or direct HTML in Markdown.

This commit also replaces manual `static()` calls with `static/...`
where possible.