### PR TITLE
Make MI-PYT materials presentable

### DIFF
--- a/courses/mi-pyt/info.yml
+++ b/courses/mi-pyt/info.yml
@@ -3,18 +3,13 @@ description: Základy již znáte a chcete se dozvědět o dalších možnostech
 long_description: |
     Díváte se na materiály předmětu MI-PYT (Pokročilý Python) na FIT ČVUT.
     Materiály jsou dostupné v dvojí podobě, interně pro studenty FITu
-    na *Eduxu* a pro všechny veřejně na [GitHubu].
+    na *Eduxu* a pro všechny veřejně zde.
 
-    Kde není uvedeno jinak, jsou materiály dostupné pod licencí Creative
-    Commons Attribution-ShareAlike 4.0 International, kde autorem je
-    Petr Viktorin a Miro Hrončok (vyučující předmětu) a další přispěvatelé.
     Tento kurz vzniká pod záštitou firmy Red Hat Czech, s.r.o.
-
-    [Githubu]: https://github.com/cvut/MI-PYT
 
 base_collection: intro
 plan:
-- title: Lekce
+- title: Obsah
   slug: session
   materials:
   - lesson: fast-track/install

--- a/naucse/routes.py
+++ b/naucse/routes.py
@@ -103,8 +103,7 @@ def lesson_static(lesson, path):
 def course_page(course):
     try:
         return render_template('course.html',
-                               course=course, plan=course.sessions,
-                               page_wip=True)
+                               course=course, plan=course.sessions)
     except TemplateNotFound:
         abort(404)
 
@@ -205,7 +204,7 @@ def run_page(run, lesson, page, solution=None):
 def lesson(lesson, page, solution=None):
     """Render the html of the given lesson page."""
     page = lesson.pages[page]
-    return render_page(page=page, page_wip=True, solution=solution)
+    return render_page(page=page, solution=solution)
 
 
 @app.route('/runs/<run:run>/sessions/<session>/', defaults={'coverpage': 'front'})

--- a/naucse/templates/_base.html
+++ b/naucse/templates/_base.html
@@ -62,38 +62,8 @@
 
         <script type="text/javascript" src="{{ url_for('static', filename='js/solutions.js') }}"></script>
 
-        {% if not var('book-style') %}
-        <div class="footer">
-            <div class="container">
-                <div class="row">
-                    <div class="col">
-                        <h2>Kontakt</h2>
-                        <p>
-                            E-mail: <a href="mailto:info@pyvec.org">info@pyvec.org</a><br>
-                            GitHub: <a href="http://github.com/pyvec">github.com/pyvec</a><br>
-                            Twitter: <a href="http://twitter.com/pyvec">@pyvec</a><br>
-                            Youtube: <a href="http://www.youtube.com/pyvec">www.youtube.com/pyvec</a>
-                        </p>
-                    </div>
-                    <div class="col">
-                        <h2>Zapoj se</h2>
-                        <p>
-                            Tyto stránky na <a href="https://github.com/pyvec/naucse.python.cz">GitHubu</a>
-                            <br>
-                            Organizuj <a href="http://pyladies.cz/stan_se/">PyLadies</a>
-                        </p>
-                    </div>
-                    <div class="col">
-                        <h2>Licence</h2>
-                        <p>
-                            <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International</a>
-                        </p>
-                    </div>
-                </div>
-            </div>
-        </div>
-        {% endif %}
-        
+        {% block footer %}{% endblock %}
+
         <script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>

--- a/naucse/templates/_lessons_list.html
+++ b/naucse/templates/_lessons_list.html
@@ -2,6 +2,16 @@
 
 {% block content %}
 
+{% macro session_heading(session, index, plan) %}
+    {% if plan|length > 1 %}
+        Lekce {{ index }} -
+    {% endif %}
+    {{ session.title }}
+    {% if session.date %}
+        ({{ session.date }})
+    {% endif %}
+{% endmacro %}
+
 <div class="page">
     <section class="container">
 
@@ -13,18 +23,14 @@
                 {% for session in plan.values() %}
                 <div class="section{{ loop.index }}">
                     <h4>
-                    {% if run is defined %}
-                        <a href="{{ session_url(run.slug, session.slug) }}">
-                        {% if session.date %}
-                            Lekce {{ loop.index }} - {{ session.title }} ({{ session.date }})
+                        {% if run is defined %}
+                            <a href="{{ session_url(run.slug, session.slug) }}">
+                            {{ session_heading(session, loop.index, plan) }}
+                            </a>
                         {% else %}
-                            Lekce {{ loop.index }} - {{ session.title }}
+                            {{ session_heading(session, loop.index, plan) }}
                         {% endif %}
-                        </a>
-                    {% else %}
-                        Lekce {{ loop.index }} - {{ session.title }}
-                    {% endif %}
-                     </h4>
+                    </h4>
                     {% for mat in session.materials %}
                         <div>
                             <span class="glyphicon-pencil"></span>

--- a/naucse/templates/index.html
+++ b/naucse/templates/index.html
@@ -90,3 +90,35 @@
   </div>
 
 {% endblock %}
+
+{% block footer %}
+    <div class="footer">
+        <div class="container">
+            <div class="row">
+                <div class="col">
+                    <h2>Kontakt</h2>
+                    <p>
+                        E-mail: <a href="mailto:info@pyvec.org">info@pyvec.org</a><br>
+                        GitHub: <a href="http://github.com/pyvec">github.com/pyvec</a><br>
+                        Twitter: <a href="http://twitter.com/pyvec">@pyvec</a><br>
+                        Youtube: <a href="http://www.youtube.com/pyvec">www.youtube.com/pyvec</a>
+                    </p>
+                </div>
+                <div class="col">
+                    <h2>Zapoj se</h2>
+                    <p>
+                        Tyto stránky na <a href="https://github.com/pyvec/naucse.python.cz">GitHubu</a>
+                        <br>
+                        Organizuj <a href="http://pyladies.cz/stan_se/">PyLadies</a>
+                    </p>
+                </div>
+                <div class="col">
+                    <h2>Licence</h2>
+                    <p>
+                        <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock footer %}


### PR DESCRIPTION
We want to link to MI-PYT course materials from the blog. This removes the "in progress" warnings, and makes some minor styling improvements.
Not ideal, but it should be enough.