### PR TITLE
Oprav chybný název třídy v Asteroidech.

### DIFF
--- a/lessons/projects/asteroids/index.md
+++ b/lessons/projects/asteroids/index.md
@@ -165,7 +165,7 @@ Přidej druhý typ vesmírného objektu: `Asteroid`.
   pomocí klávesnice).
   Využij funkci `super()` z [lekce o dědičnosti](../../beginners/inheritance/).
 * Napiš ještě třídu `Asteroid`,
-  která taky dědí ze `Spaceship`,
+  která taky dědí ze `SpaceObject`,
   ale má svoje vlastní chování:
   může mít jednu ze čtyř velikostí,
   začíná buď na levé nebo spodní straně obrazovky*


### PR DESCRIPTION
#V lekci s Asteroidy je chybně uvedené, že by třída `Asteroid` měla dědit ze třídy `Spaceship`. Místo toho má však dědit ze třídy `SpaceObject`. Opraveno, ať to děvčata nemate – skutečně to na hodině způsobilo starosti.