### PR TITLE
Order courses/ progressively by advanceness

### DIFF
--- a/courses/info.yml
+++ b/courses/info.yml
@@ -1,0 +1,2 @@
+- pyladies
+- mi-pyt

--- a/courses/info.yml
+++ b/courses/info.yml
@@ -1,2 +1,3 @@
+order:
 - pyladies
 - mi-pyt

--- a/naucse/modelutils.py
+++ b/naucse/modelutils.py
@@ -103,7 +103,7 @@ class DirProperty(LazyProperty):
         info_path = base.joinpath("info.yml")
         if info_path.is_file():
             with info_path.open(encoding='utf-8') as f:
-                model_paths = [base.joinpath(p) for p in yaml.safe_load(f)]
+                model_paths = [base.joinpath(p) for p in yaml.safe_load(f)['order']]
         
         subdirectories = [p for p in sorted(base.iterdir()) if p.is_dir()]
         return OrderedDict(


### PR DESCRIPTION
Previously, _MI-PYT_ was listed before _Začátečnický kurz_.

This enables `DirProperty` to make use of a `info.yml` file for the ordering.