### PR TITLE
Travis CI: Use pypy3 to speed up the freezing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
+dist: trusty
 python:
-- '3.5'
+- 'pypy3.5-5.8.0'
 cache:
 - pip
 install:


### PR DESCRIPTION
I've used pypy3.5 (from [Copr]) locally to speed up the freezing by 46 %. Decided to try this on Travis CI as well. It appears to speed the build up as well (less than two minutes &times; more than 3 minutes), although the speed of the Travis build might be affected by external factors. I suggest we try to use this for some time and see, if it makes any difference.

Note that I didn't try deploying the website from Travis yet, we can live-test it during the merge.

Using PyPy 3 instead of CPython is cool. However it might bring unexpected problems. But I think we can afford to merge this and revert later if necessary.
 
The speedup here is not that significant, but the speedup of local freeze is quite noticeable. I would like to use the same tools locally and on Travis, if possible.

[Copr]: http://copr.fedorainfracloud.org/coprs/g/python/pypy35/