### PR TITLE
Opravy v lekci o Gitu

### DIFF
--- a/lessons/git/basics/index.md
+++ b/lessons/git/basics/index.md
@@ -240,11 +240,13 @@ Pak se opět zeptej Gitu na stav repozitáře.
 ```ansi
 ␛[36m$␛[0m git status
 On branch master
-Changes to be committed:
-  (use "git reset HEAD <file>..." to unstage)
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git checkout -- <file>..." to discard changes in working directory)
 
-        ␛[32mmodified:   basnicka.txt␛[m
+        ␛[31mmodified:   basnicka.txt␛[m
 
+no changes added to commit (use "git add" and/or "git commit -a")
 ```
 
 Soubor je opět červený! Něco se v něm změnilo!

--- a/lessons/git/install/index.md
+++ b/lessons/git/install/index.md
@@ -58,6 +58,7 @@ V nové příkazové řádce zadej:
 ```console
 > git config --global core.editor notepad
 > git config --global format.commitMessageColumns 80
+> git config --global gui.encoding utf-8
 ```
 
 A teď pokračuj v sekci [Nastavením](#config) níže – macOS přeskoč.


### PR DESCRIPTION
- Vypadá to že `gitk` ve Windows 10 používá nějaké pochybné kódování; nastaveno na UTF-8.
- Oprava výstupu z `git status`