### PR TITLE
Allow specifying CC0 as license for code snippets

### DIFF
--- a/licenses/cc0/info.yml
+++ b/licenses/cc0/info.yml
@@ -1,0 +1,2 @@
+title: CC0 1.0 Universal Public Domain Dedication
+url: https://creativecommons.org/publicdomain/zero/1.0/

--- a/naucse/markdown_util.py
+++ b/naucse/markdown_util.py
@@ -195,7 +195,7 @@ def convert_markdown(text, convert_url=None, *, inline=False):
         block=BlockLexer(),
         renderer=Renderer(convert_url),
     )
-    result = Markup(markdown(text))
+    result = Markup(markdown(text)).strip()
 
     if inline and result.startswith('<p>') and result.endswith('</p>'):
         result = result[len('<p>'):-len('</p>')]

--- a/naucse/models.py
+++ b/naucse/models.py
@@ -86,6 +86,12 @@ class Page(Model):
         return self.root.licenses[self.info['license']]
 
     @reify
+    def license_code(self):
+        if 'license_code' in self.info:
+            return self.root.licenses[self.info['license_code']]
+        return None
+
+    @reify
     def vars(self):
         return self.info.get('vars', {})
 

--- a/naucse/templates/_base.html
+++ b/naucse/templates/_base.html
@@ -62,7 +62,7 @@
                     </p>
                 {% else %}
                     <p>
-                        Licence: <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International</a>
+                        Licence: <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International</a> není-li uvedeno jinak
                     </p>
                 {% endif %}
             </div>

--- a/naucse/templates/_base.html
+++ b/naucse/templates/_base.html
@@ -59,6 +59,14 @@
                         <a href="{{ page.license.url }}">
                             {{ page.license.title }}
                         </a>
+                        {% if page.license_code %}
+                    </p>
+                    <p>
+                        Licence ukázek kódu:
+                        <a href="{{ page.license_code.url }}">
+                            {{ page.license_code.title }}
+                        </a>
+                        {% endif %}
                     </p>
                 {% else %}
                     <p>


### PR DESCRIPTION
Note that the markdown strip commit is unrelated, but the problem was discovered during implementation of an alternate solution that was later abandoned, so I decided to keep it here.