### PR TITLE
Correctly capitalize "PyLadies" (and remove unnecessary occurences)

### DIFF
--- a/lessons/beginners/and-or/info.yml
+++ b/lessons/beginners/and-or/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: Nebo anebo a
 style: md
 attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017.

--- a/lessons/beginners/cmdline/info.yml
+++ b/lessons/beginners/cmdline/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: Úvod do příkazové řádky
 style: md
 attribution:

--- a/lessons/beginners/comparisons/info.yml
+++ b/lessons/beginners/comparisons/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: Porovnávání
 style: md
 attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017.

--- a/lessons/beginners/def/info.yml
+++ b/lessons/beginners/def/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: Vlastní funkce
 style: md
 attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017.

--- a/lessons/beginners/first-steps/info.yml
+++ b/lessons/beginners/first-steps/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: První krůčky
 style: md
 attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017.

--- a/lessons/beginners/hello-world/info.yml
+++ b/lessons/beginners/hello-world/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: První program
 style: md
 attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017.

--- a/lessons/beginners/install-editor/info.yml
+++ b/lessons/beginners/install-editor/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: Instalace editoru
 style: md
 attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017

--- a/lessons/beginners/install/info.yml
+++ b/lessons/beginners/install/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: Instalace Pythonu
 style: md
 attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017.

--- a/lessons/beginners/print/info.yml
+++ b/lessons/beginners/print/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: Print a chybové hlášky
 style: md
 attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017.

--- a/lessons/beginners/variables/info.yml
+++ b/lessons/beginners/variables/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: Proměnné
 style: md
 attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017.

--- a/lessons/beginners/while/info.yml
+++ b/lessons/beginners/while/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: Cyklus While
 style: md
 attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017.

--- a/lessons/git/basics/info.yml
+++ b/lessons/git/basics/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: Git
 style: md
 css: |

--- a/lessons/git/branching/info.yml
+++ b/lessons/git/branching/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: Větvení v Gitu
 style: md
 attribution: Pro PyLadies Brno napsal Petr Viktorin, 2015-2017.

--- a/lessons/git/install/info.yml
+++ b/lessons/git/install/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: Instalace gitu
 style: md
 attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017

--- a/lessons/intro/turtle/info.yml
+++ b/lessons/intro/turtle/info.yml
@@ -1,4 +1,3 @@
-course: Pyladies
 title: Želva a cykly
 style: md
 attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017.

--- a/lessons/projects/asteroids/static/info.yml
+++ b/lessons/projects/asteroids/static/info.yml
@@ -1,3 +1,0 @@
-course: Pyladies
-title: 
-style: html

--- a/runs/2017/pyladies-brno-jaro-po/info.yml
+++ b/runs/2017/pyladies-brno-jaro-po/info.yml
@@ -1,4 +1,4 @@
-title: Začátečnický kurz Pyladies
+title: Začátečnický kurz PyLadies
 subtitle: Brno - jaro 2017 - pondělí
 time: 18:00–20:00
 place: Odbor školství, Cejl 73, Brno
@@ -7,7 +7,7 @@ long_description: |
     Tady najdeš všechny materiály k brněnské verzi začátečnického kurzu
     PyLadies.
 
-    Stránky samotných PyLadies jsou na [http://pyladies.cz][Pyladies].
+    Stránky samotných PyLadies jsou na [http://pyladies.cz][PyLadies].
 
     Jednotlivé lekce jsou určeny naprostým začátečnicím.
     Instrukce jsou uvedeny pro operační systémy Linux, Windows i macOS.

--- a/runs/2017/pyladies-brno-podzim-po/info.yml
+++ b/runs/2017/pyladies-brno-podzim-po/info.yml
@@ -1,4 +1,4 @@
-title: Začátečnický kurz Pyladies
+title: Začátečnický kurz PyLadies
 subtitle: Brno - podzim 2017 - pondělí
 time: 18:00–20:00
 place: Experis, BC Titanuim, Nové sady 996/25
@@ -7,7 +7,7 @@ long_description: |
     Tady najdeš všechny materiály k brněnské verzi začátečnického kurzu
     PyLadies.
 
-    Stránky samotných PyLadies jsou na [http://pyladies.cz][Pyladies].
+    Stránky samotných PyLadies jsou na [http://pyladies.cz][PyLadies].
 
     Jednotlivé lekce jsou určeny naprostým začátečnicím.
     Instrukce jsou uvedeny pro operační systémy Linux, Windows i macOS.

--- a/runs/2017/pyladies-ostrava-jaro/info.yml
+++ b/runs/2017/pyladies-ostrava-jaro/info.yml
@@ -1,4 +1,4 @@
-title: Začátečnický kurz Pyladies
+title: Začátečnický kurz PyLadies
 subtitle: Ostrava - jaro 2017
 time: 17:00–19:00
 place: Tieto Towers, 28.října 3346/91, Ostrava
@@ -7,7 +7,7 @@ long_description: |
     Tady najdeš všechny materiály k ostravské verzi začátečnického kurzu
     PyLadies.
 
-    Stránky samotných PyLadies jsou na [http://pyladies.cz][Pyladies].
+    Stránky samotných PyLadies jsou na [http://pyladies.cz][PyLadies].
 
     Jednotlivé lekce jsou určeny naprostým začátečnicím.
     Instrukce jsou uvedeny pro operační systémy Linux, Windows i macOS.

--- a/runs/2017/pyladies-ostrava-podzim/info.yml
+++ b/runs/2017/pyladies-ostrava-podzim/info.yml
@@ -1,4 +1,4 @@
-title: Začátečnický kurz Pyladies
+title: Začátečnický kurz PyLadies
 subtitle: Ostrava - podzim 2017
 time: 17:00–19:00
 place: Tieto Towers, 28.října 3346/91, Ostrava
@@ -7,7 +7,7 @@ long_description: |
     Tady najdeš všechny materiály k ostravské verzi začátečnického kurzu
     PyLadies.
 
-    Stránky samotných PyLadies jsou na [http://pyladies.cz][Pyladies].
+    Stránky samotných PyLadies jsou na [http://pyladies.cz][PyLadies].
 
     Jednotlivé lekce jsou určeny naprostým začátečnicím.
     Instrukce jsou uvedeny pro operační systémy Linux, Windows i macOS.

--- a/runs/2017/pyladies-praha-jaro/info.yml
+++ b/runs/2017/pyladies-praha-jaro/info.yml
@@ -1,4 +1,4 @@
-title: Začátečnický kurz Pyladies
+title: Začátečnický kurz PyLadies
 subtitle: Praha - jaro 2017
 time: 18:00–20:00
 place: budova CZ.NIC, Milešovská 5, Praha 3
@@ -7,7 +7,7 @@ long_description: |
     Tady najdeš všechny materiály k brněnské verzi začátečnického kurzu
     PyLadies.
 
-    Stránky samotných PyLadies jsou na [http://pyladies.cz][Pyladies].
+    Stránky samotných PyLadies jsou na [http://pyladies.cz][PyLadies].
 
     Jednotlivé lekce jsou určeny naprostým začátečnicím.
     Instrukce jsou uvedeny pro operační systémy Linux, Windows i macOS.

--- a/runs/2017/pyladies-praha-podzim-cznic/info.yml
+++ b/runs/2017/pyladies-praha-podzim-cznic/info.yml
@@ -1,4 +1,4 @@
-title: Začátečnický kurz Pyladies
+title: Začátečnický kurz PyLadies
 subtitle: Praha (CZ.NIC) - podzim 2017
 time: 18:00–20:00
 place: budova CZ.NIC, Milešovská 5, Praha 3
@@ -7,7 +7,7 @@ long_description: |
     Tady najdeš všechny materiály k brněnské verzi začátečnického kurzu
     PyLadies.
 
-    Stránky samotných PyLadies jsou na [http://pyladies.cz][Pyladies].
+    Stránky samotných PyLadies jsou na [http://pyladies.cz][PyLadies].
 
     Jednotlivé lekce jsou určeny naprostým začátečnicím.
     Instrukce jsou uvedeny pro operační systémy Linux, Windows i macOS.

--- a/runs/2017/pyladies-praha-podzim-ntk/info.yml
+++ b/runs/2017/pyladies-praha-podzim-ntk/info.yml
@@ -1,4 +1,4 @@
-title: Začátečnický kurz Pyladies
+title: Začátečnický kurz PyLadies
 subtitle: Praha (NTK) - podzim 2017
 time: 18:00–20:00
 place: Národní technická knihovna, Technická 2710/6, Praha 6
@@ -7,7 +7,7 @@ long_description: |
     Tady najdeš všechny materiály k brněnské verzi začátečnického kurzu
     PyLadies.
 
-    Stránky samotných PyLadies jsou na [http://pyladies.cz][Pyladies].
+    Stránky samotných PyLadies jsou na [http://pyladies.cz][PyLadies].
 
     Jednotlivé lekce jsou určeny naprostým začátečnicím.
     Instrukce jsou uvedeny pro operační systémy Linux, Windows i macOS.


### PR DESCRIPTION
The `course` item in lesson info is unused.
The `info.yml` file in a `static` directory is unused.
Use correct capitalization everywhere else.

Incidentally, fixes: https://github.com/pyvec/naucse.python.cz/issues/271