### PR TITLE
Travis CI: Use Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-- '3.5'
+- '3.6'
 cache:
 - pip
 install:


### PR DESCRIPTION
Use the same version of Python most of us will get when following the instructions in README. Be modern!