### PR TITLE
Oprav příklad spouštění testů

### DIFF
--- a/lessons/beginners/testing/index.md
+++ b/lessons/beginners/testing/index.md
@@ -135,7 +135,7 @@ test_secteni.py::test_secti ␛[32mPASSED␛[0m
 
 Tento příkaz projde zadaný soubor, zavolá v něm všechny funkce,
 jejichž jméno začíná na `test_`, a ověří, že nevyvolají žádnou
-výjimku – typicky výjimku z příkazu `assert`.
+výjimku — typicky výjimku z příkazu `assert`.
 Pokud výjimka nastane, dá to `pytest` velice červeně
 najevo a přidá několik informací, které můžou
 usnadnit nalezení a opravu chyby.

--- a/lessons/beginners/testing/index.md
+++ b/lessons/beginners/testing/index.md
@@ -141,6 +141,11 @@ Pokud výjimka nastane, dá to `pytest` velice červeně
 najevo a přidá několik informací, které můžou
 usnadnit nalezení a opravu chyby.
 
+> [note]
+> Pokud bychom chtěli spustit testy jen z jednoho souboru nebo složky,
+> můžeme ji tomuto příkazu přidat jako další argument.
+> Např. v našem případě: `python -m pytest -v test_secteni.py`
+
 Zkus si změnit funkci `secti` (nebo její test) a podívat se,
 jak to vypadá když test „neprojde“.
 

--- a/lessons/beginners/testing/index.md
+++ b/lessons/beginners/testing/index.md
@@ -142,9 +142,9 @@ usnadnit nalezení a opravu chyby.
 
 > [note]
 > Argument s názvem souboru můžeme vynechat: `python -m pytest -v`
-> V takovém případě Pytest projde aktuální adresář a spustí testy
+> V takovém případě `pytest` projde aktuální adresář a spustí testy
 > ze všech souborů, jejichž jméno začíná na `test_`. Místo souboru
-> lze též uvést adresář a Pytest vyhledá testy v něm.
+> lze též uvést adresář a `pytest` vyhledá testy v něm.
 
 Zkus si změnit funkci `secti` (nebo její test) a podívat se,
 jak to vypadá když test „neprojde“.

--- a/lessons/beginners/testing/index.md
+++ b/lessons/beginners/testing/index.md
@@ -121,7 +121,7 @@ tedy v překladu: <strong>Python</strong>e, pusť
 v „ukecaném” režimu (angl. <strong>v</strong>erbose).
 
 ```ansi
-$ python -m pytest -v test_secteni.py 
+$ python -m pytest -v
 ␛[1m============= test session starts =============␛[0m
 platform linux -- Python 3.6.0, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- env/bin/python
 cachedir: .cache

--- a/lessons/beginners/testing/index.md
+++ b/lessons/beginners/testing/index.md
@@ -115,13 +115,13 @@ if not (a == b):
 ## Spouštění testů
 
 Testy se spouští zadáním příkazu
-`python -m pytest -v`,
-tedy v překladu: <strong>Python</strong>e, pusť
+`python -m pytest -v` následovaným názvem souboru s testy.
+Tedy v překladu: <strong>Python</strong>e, pusť
 <strong>m</strong>odul <strong>pytest</strong>,
-v „ukecaném” režimu (angl. <strong>v</strong>erbose).
+v „ukecaném” režimu (angl. <strong>v</strong>erbose) nad zadaným souborem.
 
 ```ansi
-$ python -m pytest -v
+$ python -m pytest -v test_secteni.py
 ␛[1m============= test session starts =============␛[0m
 platform linux -- Python 3.6.0, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- env/bin/python
 cachedir: .cache
@@ -133,18 +133,18 @@ test_secteni.py::test_secti ␛[32mPASSED␛[0m
 ␛[32m============= 1 passed in 0.00 seconds =============␛[0m
 ```
 
-Tento příkaz projde všechny soubory v aktuálním
-adresáři, jejichž jméno začíná na `test_`, zavolá v nich všechny funkce,
+Tento příkaz projde zadaný soubor, zavolá v něm všechny funkce,
 jejichž jméno začíná na `test_`, a ověří, že nevyvolají žádnou
-výjimku — typicky výjimku z příkazu `assert`.
+výjimku – typicky výjimku z příkazu `assert`.
 Pokud výjimka nastane, dá to `pytest` velice červeně
 najevo a přidá několik informací, které můžou
 usnadnit nalezení a opravu chyby.
 
 > [note]
-> Pokud bychom chtěli spustit testy jen z jednoho souboru nebo složky,
-> můžeme ji tomuto příkazu přidat jako další argument.
-> Např. v našem případě: `python -m pytest -v test_secteni.py`
+> Argument s názvem souboru můžeme vynechat: `python -m pytest -v`
+> V takovém případě Pytest projde aktuální adresář a spustí testy
+> ze všech souborů, jejichž jméno začíná na `test_`. Místo souboru
+> lze též uvést adresář a Pytest vyhledá testy v něm.
 
 Zkus si změnit funkci `secti` (nebo její test) a podívat se,
 jak to vypadá když test „neprojde“.


### PR DESCRIPTION
V kapitole o testování se hned nad příkladem píše, že se testy
spouštějí příkazem `python -m pytest -v`, tedy bez uvedeného názvu
souboru. Níže se navíc píše, že si ty soubory sám najde. V samotném
příkladu se však spouští příkaz i s uvedeným souborem. Název souboru
z příkladu odebrán, výstup ponechán stejný – měl by být stejný, neboť
jsme si zatím vytvořili jen jeden test.