### PR TITLE
Cython: Split setup_requires and install_requires

### DIFF
--- a/lessons/intro/cython/index.md
+++ b/lessons/intro/cython/index.md
@@ -459,8 +459,11 @@ setup(
     name='matmul',
     ext_modules=cythonize('matmul.pyx', language_level=3),
     include_dirs=[numpy.get_include()],
-    install_requires=[
+    setup_requires=[
         'Cython',
+        'NumPy',
+    ],
+    install_requires=[
         'NumPy',
     ],
 )


### PR DESCRIPTION
When creating wheel, this matters.
Our built module does not require Cython at all.