### PR TITLE
Pyglet: Black snake in black window is a bad idea

### DIFF
--- a/lessons/intro/pyglet/index.md
+++ b/lessons/intro/pyglet/index.md
@@ -282,6 +282,8 @@ Najdi si na Internetu nějaký obrázek. Ne moc velký,
 tak 3cm, ať je kolem něj v našem černém okýnku dost
 místa, a nejlépe ve formátu PNG. Začni třeba na
 [téhle stránce](https://www.google.cz/search?tbs=ift:png&tbm=isch&q=snake+icon).
+Ale nevybírej obrázek, který je celý černý, protože by v našem černém okně
+nebyl vidět.
 Ulož si ho do adresáře, odkud spouštíš svůj pythonní
 program. Já mám třeba obrázek hada v souboru `had.png`.
 


### PR DESCRIPTION
This is what I see when I Google snake icon (as the link suggests):

![snake](https://user-images.githubusercontent.com/2401856/33243271-10f18ec0-d2e3-11e7-885f-f95fdb373466.png)

Let's say picking a black snake icon is a bad idea, because, frankly, it is:

![blacksnake](https://user-images.githubusercontent.com/2401856/33243278-3c94afee-d2e3-11e7-97e6-604d785bde98.png)

