### PR TITLE
PyQt: Add link to pyqt5-tools wheels

### DIFF
--- a/lessons/intro/pyqt/index.md
+++ b/lessons/intro/pyqt/index.md
@@ -53,6 +53,12 @@ $ brew install qt5
 $ brew linkapps qt5
 ```
 
+Existují i Python wheely [pyqt5-tools] pro Windows obsahující Qt5 Designer.
+Ten je pak potřeba pro spuštění dohledat v nainstalované lokaci.
+
+[pyqt5-tools]: https://pypi.python.org/pypi/pyqt5-tools
+
+
 ### NumPy
 
 Do virtuálního prostředí s PyQt5 si nainstalujte i NumPy:


### PR DESCRIPTION
This deliberately uses the old PyPI, because the new
Warehouse does not show the download files there.