### PR TITLE
intro/magic: Don't inherit from object in Python 3

### DIFF
--- a/lessons/intro/magic/index.md
+++ b/lessons/intro/magic/index.md
@@ -486,7 +486,7 @@ Funguje podobně jako `@property`, jen se výsledek vypočítá pouze jednou a u
 Při dalším přístupu k atributu už se použije uložená hodnota.
 
 ```python
-class reify(object):
+class reify:
     def __init__(self, func):
         self.func = func
 


### PR DESCRIPTION
Let's keep the code Python 3 only not to bother readers with Legacy Python