### PR TITLE
Pep8 checks

### DIFF
--- a/lessons/beginners/install-editor/atom.md
+++ b/lessons/beginners/install-editor/atom.md
@@ -17,14 +17,18 @@ měl{{a}} bys ho co nejdřív uložit pod správným jménem.
 
 ## Kontrola stylu zdrojového kódu
 
-Jedna věc nám v Atomu přeci jen chybí a to plugin pro kontrolu správného
+Jedna věc nám v Atomu přeci jen chybí: plugin pro kontrolu správného
 stylu zdrojového kódu.
 
-Python má pravidla pro psaní zdrojového kódu popsána v dokumentu
-[PEP8](https://www.python.org/dev/peps/pep-0008/). Nejsou závazná a program
-bude fungovat i při jejich nedodržení, ale jejich dodržování přinejmenším
-přispívá k lepší čitelnosti napsaného kódu. Abychom si je nemuseli všechny
-pamatovat, nainstalujeme si plugin, který nás na jejich porušení upozorní.
+Tak jako čeština má Python typografická providla.
+Například za čárkou se píše mezera, ale před ní ne.
+Jsou nepovinná, program bude fungovat i při jejich nedodržení,
+ale pomáhají psát přehledný kód, tak je dobré je dodržovat už od začátku.
+Pravidla pro Python jsou popsána v dokumentu
+[PEP8](https://www.python.org/dev/peps/pep-0008/).
+
+Aby sis je nemusel{{a}} všechny pamatovat, nainstaluj si plugin,
+který tě na jejich porušení upozorní.
 
 Nejprve je potřeba si nainstalovat speciální knihovnu, která se o kontrolu
 dokáže postarat. Do příkazové řádky zadej následující:
@@ -33,7 +37,7 @@ dokáže postarat. Do příkazové řádky zadej následující:
 $ python -m pip install flake8
 ```
 
-A nyní si nainstalujeme plugin do samotného editoru. V hlavní nabídce vyber
+A nyní si nainstaluj plugin do samotného editoru. V hlavní nabídce vyber
 „Soubor > Nastavení<span class="en">/File > Settings</span>“ a v nabídce
 uprostřed okna vyber poslední položku
 „Instalovat<span class="en">/Install</span>“. Do vyhledávacího pole zadej

--- a/lessons/beginners/install-editor/atom.md
+++ b/lessons/beginners/install-editor/atom.md
@@ -15,4 +15,30 @@ V jiných programovacích jazycích se totiž odsazuje i obarvuje jinak.
 Proto jakmile v tomhle editoru vytvoříš nový soubor,
 měl{{a}} bys ho co nejdřív uložit pod správným jménem.
 
+## Kontrola stylu zdrojového kódu
+
+Jedna věc nám v Atomu přeci jen chybí a to plugin pro kontrolu správného
+stylu zdrojového kódu.
+
+Python má pravidla pro psaní zdrojového kódu popsána v dokumentu
+[PEP8](https://www.python.org/dev/peps/pep-0008/). Nejsou závazná a program
+bude fungovat i při jejich nedodržení, ale jejich dodržování přinejmenším
+přispívá k lepší čitelnosti napsaného kódu. Abychom si je nemuseli všechny
+pamatovat, nainstalujeme si plugin, který nás na jejich porušení upozorní.
+
+Nejprve je potřeba si nainstalovat speciální knihovnu, která se o kontrolu
+dokáže postarat. Do příkazové řádky zadej následující:
+
+```console
+$ python -m pip install flake8
+```
+
+A nyní si nainstalujeme plugin do samotného editoru. V hlavní nabídce vyber
+„Soubor > Nastavení<span class="en">/File > Settings</span>“ a v nabídce
+uprostřed okna vyber poslední položku
+„Instalovat<span class="en">/Install</span>“. Do vyhledávacího pole zadej
+„linter-flake8“ a v seznamu nalezených pluginů klikni u položky stejného jména
+na tlačítko „Instalovat<span class="en">/Install</span>“. Bude ještě potřeba
+schválit instalaci všech závislostí, na které se Atom postupně zeptá.
+
 {% endblock %}

--- a/lessons/beginners/install-editor/others.md
+++ b/lessons/beginners/install-editor/others.md
@@ -46,4 +46,11 @@ Nejde-li vybírat po jednotlivých mezerách, nebo pokud se jich po stisknutí
 <kbd>Tab</kbd> vloží jiný počet než 4, podívej se do nastavení po možnostech
 jako „velikost odsazení“ nebo „nahrazovat tabulátory za mezery”.
 
+## Kontrola stylu zdrojového kódu
+
+Editory často podporují instalaci pluginů, které mohou psaní kódu usnadnit
+a pomoci s jeho kontrolou. Doporučujeme si nainstalovat alespoň plugin, který
+hlídá dodržování konvencí při psaní kódu v Pythonu. Tato pravidla jsou popsána
+v dokumentu [PEP8](https://www.python.org/dev/peps/pep-0008/).
+
 {% endblock %}

--- a/lessons/beginners/install-editor/others.md
+++ b/lessons/beginners/install-editor/others.md
@@ -46,11 +46,20 @@ Nejde-li vybírat po jednotlivých mezerách, nebo pokud se jich po stisknutí
 <kbd>Tab</kbd> vloží jiný počet než 4, podívej se do nastavení po možnostech
 jako „velikost odsazení“ nebo „nahrazovat tabulátory za mezery”.
 
+
 ## Kontrola stylu zdrojového kódu
 
 Editory často podporují instalaci pluginů, které mohou psaní kódu usnadnit
-a pomoci s jeho kontrolou. Doporučujeme si nainstalovat alespoň plugin, který
-hlídá dodržování konvencí při psaní kódu v Pythonu. Tato pravidla jsou popsána
-v dokumentu [PEP8](https://www.python.org/dev/peps/pep-0008/).
+a pomoci s jeho kontrolou.
+Jeden z neužitečnějších je plugin pro kontrolu správného stylu zdrojového kódu.
+
+Tak jako čeština má Python typografická providla.
+Například za čárkou se píše mezera, ale před ní ne.
+Jsou nepovinná, program bude fungovat i při jejich nedodržení,
+ale pomáhají psát přehledný kód, tak je dobré je dodržovat už od začátku.
+Tato pravidla jsou popsána
+v dokumentu [PEP8](https://www.python.org/dev/peps/pep-0008/).
+
+Zkus takový plugin pro svůj editor najít a nainstalovat.
 
 {% endblock %}


### PR DESCRIPTION
After discussion, I am adding description about installation of pep8 plugins for editors.

But the situation is not that simple. For Atom I've added simple step by step description and for other editors just a note about PEP8. But installation for Notepad++, Gedit and Kate requires a manual download of plugins and/or copying a script from various sources to right folders which may not exist on the filesystem etc.

- Notepad++ - https://kmonsoor.wordpress.com/2014/05/02/pep8_tonizer-on-for-notepad-make-your-python-code-pep8-compliant-on-editor/
- Gedit - https://github.com/khertan/gedit_flake8
- Kate - https://github.com/goinnn/Kate-plugins#id15

Question is whether is a good idea to add the complicated guide for plugins installation to editors' pages when mentioned editors aren't used widely.