### PR TITLE
Convert all cheatsheet links to GitHub pages (opens in webbrowser)

### DIFF
--- a/courses/mi-pyt/info.yml
+++ b/courses/mi-pyt/info.yml
@@ -46,7 +46,7 @@ plan:
   - lesson: intro/notebook
   - lesson: intro/numpy
   - title: Tahák na NumPy
-    url: https://github.com/pyvec/cheatsheets/raw/master/numpy/numpy-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/numpy/numpy-cs.pdf
     type: cheatsheet
 
 - title: Analýza dat – Pandas

--- a/courses/pyladies/info.yml
+++ b/courses/pyladies/info.yml
@@ -21,7 +21,7 @@ plan:
   - lesson: beginners/install-editor
   - lesson: git/install
   - title: Tahák na klávesnici (PDF)
-    url: https://github.com/pyvec/cheatsheets/raw/master/keyboard/keyboard-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/keyboard/keyboard-cs.pdf
     type: cheatsheet
 
 - title: První program
@@ -40,7 +40,7 @@ plan:
   - lesson: intro/turtle
   - lesson: beginners/while
   - title: Tahák s užitečnými funkcemi
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-functions/basic-functions-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-functions/basic-functions-cs.pdf
     type: cheatsheet
 
 - title: Správa zdrojového kódu
@@ -49,7 +49,7 @@ plan:
   - lesson: git/basics
   - lesson: git/branching
   - title: Gitový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-git/basic-git-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-git/basic-git-cs.pdf
     type: cheatsheet
 
 - title: Funkce & Řetězce
@@ -58,7 +58,7 @@ plan:
   - lesson: beginners/def
   - lesson: beginners/str
   - title: Řetězcový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/strings/strings-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/strings/strings-cs.pdf
     type: cheatsheet
 
 - title: Testování
@@ -69,7 +69,7 @@ plan:
   - lesson: beginners/testing
   - lesson: beginners/circular-imports
   - title: Výjimkový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/exceptions/exceptions-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/exceptions/exceptions-cs.pdf
     type: cheatsheet
 
 - title: Spolupráce a Open-Source
@@ -79,7 +79,7 @@ plan:
   - lesson: git/ignoring
   - lesson: beginners/files
   - title: Gitový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-git/basic-git-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-git/basic-git-cs.pdf
     type: cheatsheet
 
 - title: Seznamy
@@ -88,7 +88,7 @@ plan:
   - lesson: beginners/list
   - lesson: beginners/tuple
   - title: Tahák na seznamy
-    url: https://github.com/pyvec/cheatsheets/raw/master/lists/lists-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/lists/lists-cs.pdf
     type: cheatsheet
 
 - title: Grafika
@@ -100,7 +100,7 @@ plan:
     type: link
     url: http://pyladies.cz/v1/s012-pyglet/pong.py
   - title: Tahák na Pyglet
-    url: https://github.com/pyvec/cheatsheets/raw/master/pyglet/pyglet-basics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/pyglet/pyglet-basics-cs.pdf
     type: cheatsheet
 
 - title: Slovníky
@@ -110,7 +110,7 @@ plan:
   - lesson: intro/json
   - lesson: projects/github-api
   - title: Slovníkový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/dicts/dicts-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/dicts/dicts-cs.pdf
     type: cheatsheet
 
 - title: Třídy
@@ -124,8 +124,8 @@ plan:
   materials:
   - lesson: projects/asteroids
   - title: Množinový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/sets/sets-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/sets/sets-cs.pdf
     type: cheatsheet
   - title: Tahák na geometrii a fyziku 2D her
-    url: https://github.com/pyvec/cheatsheets/raw/master/game-physics/game-physics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/game-physics/game-physics-cs.pdf
     type: cheatsheet

--- a/lessons/beginners/dict/index.md
+++ b/lessons/beginners/dict/index.md
@@ -213,7 +213,7 @@ způsoby vytvoření `dict`.
 
 Chceš-li mít všechny triky, které  slovníky umí,
 pěkně pohromadě, můžeš si stáhnout
-[Slovníkový tahák](https://github.com/pyvec/cheatsheets/raw/master/dicts/dicts-cs.pdf).
+[Slovníkový tahák](https://pyvec.github.io/cheatsheets/dicts/dicts-cs.pdf).
 
 Kompletní popis slovníků najdeš
 v [dokumentaci](https://docs.python.org/3.0/library/stdtypes.html#mapping-types-dict)

--- a/lessons/beginners/micropython/index.md
+++ b/lessons/beginners/micropython/index.md
@@ -311,7 +311,7 @@ Funkce `pin.value()` změří napětí na dané
 No a „nožička” číslo 0 je připojená k tlačítku `FLASH`,
 kterým se tak dá ono napětí ovládat.
 Informace o tom, která nožička je kam připojená,
-máš na [taháku](https://github.com/pyvec/cheatsheets/raw/master/micropython/nodemcu-cs.pdf) –
+máš na [taháku](https://pyvec.github.io/cheatsheets/micropython/nodemcu-cs.pdf) –
 můžeš si zkontrolovat, že Pin(0) u sebe má poznámku FLASH.
 
 
@@ -425,7 +425,7 @@ A tak se dá s diodou blikat.
 > Číslování nožiček je bohužel dvojí – nožička
 > označená jako `D5` má v procesoru přiřazené číslo 14.
 > Třída `Pin` v MicroPythonu používá číslování procesoru.
-> Naštěstí máš [tahák](https://github.com/pyvec/cheatsheets/raw/master/micropython/nodemcu-cs.pdf),
+> Naštěstí máš [tahák](https://pyvec.github.io/cheatsheets/micropython/nodemcu-cs.pdf),
 > kde snadno dohledáš že `D5` a `Pin(14)` jsou dvě jména stejné nožičky.
 
 Zvládneš napsat program, který zařídí, aby dioda

--- a/lessons/beginners/str/index.md
+++ b/lessons/beginners/str/index.md
@@ -258,7 +258,7 @@ Je sice delší, ale mnohem přehlednější.
 {% endfilter %}
 
 Řetězcových metod je celá řada.
-Nejužitečnější z nich najdeš v [taháku](https://github.com/pyvec/cheatsheets/raw/master/strings/strings-cs.pdf), který si můžeš stáhnout či vytisknout.
+Nejužitečnější z nich najdeš v [taháku](https://pyvec.github.io/cheatsheets/strings/strings-cs.pdf), který si můžeš stáhnout či vytisknout.
 
 A úplně všechny řetězcové metody jsou popsány v [dokumentaci Pythonu](https://docs.python.org/3/library/stdtypes.html#string-methods) (anglicky; plné věcí, které ještě neznáš).
 

--- a/lessons/intro/micropython/index.md
+++ b/lessons/intro/micropython/index.md
@@ -90,7 +90,7 @@ pin.value(1)
 Pro zhasnutí zadejte `pin.value(0)`. (Opět jde o volání metody, není to `pin.value = 0`.)
 
 `Pin(14)` odpovídá pinu označenému `D5` – číslování, které používá procesor (a MicroPython), se bohužel liší od toho, které používá deska.
-Odpovídající si označení lze zjistit z [taháku](https://github.com/pyvec/cheatsheets/raw/master/micropython/nodemcu-cs.pdf).
+Odpovídající si označení lze zjistit z [taháku](https://pyvec.github.io/cheatsheets/micropython/nodemcu-cs.pdf).
 
 Zkuste zajistit, aby dioda svítila, právě pokud je stisknuté tlačítko FLASH.
 

--- a/lessons/intro/pyglet/index.md
+++ b/lessons/intro/pyglet/index.md
@@ -540,7 +540,7 @@ Kdyby komentáře nestačily, jsou k Pongu připravené
 i [podrobné materiály]({{ lesson_url('projects/pong') }}).
 
 To, co jsme tu probral{{gnd('i', 'y', both='i')}} a pár věcí navíc,
-je shrnuto v [taháku na Pyglet](https://github.com/pyvec/cheatsheets/raw/master/pyglet/pyglet-basics-cs.pdf),
+je shrnuto v [taháku na Pyglet](https://pyvec.github.io/cheatsheets/pyglet/pyglet-basics-cs.pdf),
 který si můžeš stáhnout a vytisknout.
 
 A chceš-li se do Pygletu ponořit hlouběji,

--- a/runs/2017/mipyt-zima/info.yml
+++ b/runs/2017/mipyt-zima/info.yml
@@ -52,7 +52,7 @@ plan:
   materials:
   - lesson: intro/numpy
   - title: Tahák na NumPy
-    url: https://github.com/pyvec/cheatsheets/raw/master/numpy/numpy-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/numpy/numpy-cs.pdf
     type: cheatsheet
   - title: Zadání úkolu
     url: https://github.com/cvut/MI-PYT/blob/b171/tutorials/05_numpy.md#%C3%9Akol

--- a/runs/2017/pyladies-brno-jaro-po/info.yml
+++ b/runs/2017/pyladies-brno-jaro-po/info.yml
@@ -37,7 +37,7 @@ plan:
   - lesson: git/install
     type: lesson
   - title: Tahák na klávesnici (PDF)
-    url: https://github.com/pyvec/cheatsheets/raw/master/keyboard/keyboard-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/keyboard/keyboard-cs.pdf
     type: cheatsheet
   - title: Instrukce a domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s001-install/handout/handout.pdf
@@ -72,7 +72,7 @@ plan:
   - lesson: beginners/while
     type: lesson
   - title: Tahák s užitečnými funkcemi
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-functions/basic-functions-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-functions/basic-functions-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s003-looping/handout/handout3a.pdf
@@ -86,7 +86,7 @@ plan:
   - lesson: git/branching
     type: lesson
   - title: Gitový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-git/basic-git-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-git/basic-git-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s003-looping/handout/handout3b.pdf
@@ -100,7 +100,7 @@ plan:
   - lesson: beginners/str
     type: lesson
   - title: Řetězcový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/strings/strings-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/strings/strings-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: http://pyladies.cz/v1/s004-strings/handout/handout4.pdf
@@ -152,7 +152,7 @@ plan:
   - lesson: beginners/tuple
     type: lesson
   - title: Tahák na seznamy
-    url: https://github.com/pyvec/cheatsheets/raw/master/lists/lists-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/lists/lists-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: http://pyladies.cz/v1/s006-lists/handout/handout6.pdf
@@ -168,7 +168,7 @@ plan:
   - lesson: projects/github-api
     type: lesson
   - title: Slovníkový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/dicts/dicts-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/dicts/dicts-cs.pdf
     type: cheatsheet
 - title: Grafika
   slug: pyglet
@@ -182,7 +182,7 @@ plan:
     type: link
     url: http://pyladies.cz/v1/s012-pyglet/pong.py
   - title: Tahák na Pyglet
-    url: https://github.com/pyvec/cheatsheets/raw/master/pyglet/pyglet-basics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/pyglet/pyglet-basics-cs.pdf
     type: cheatsheet
 - title: Třídy
   slug: class
@@ -199,10 +199,10 @@ plan:
   - lesson: projects/asteroids
     type: lesson
   - title: Množinový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/sets/sets-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/sets/sets-cs.pdf
     type: cheatsheet
   - title: Tahák na geometrii a fyziku 2D her
-    url: https://github.com/pyvec/cheatsheets/raw/master/game-physics/game-physics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/game-physics/game-physics-cs.pdf
     type: cheatsheet
 - title: MicroPython
   slug: micropython

--- a/runs/2017/pyladies-brno-podzim-po/info.yml
+++ b/runs/2017/pyladies-brno-podzim-po/info.yml
@@ -81,7 +81,7 @@ plan:
   - lesson: git/collaboration
   - lesson: beginners/files
   - title: Gitový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-git/basic-git-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-git/basic-git-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: http://pyladies.cz/v1/s005-modules/handout/handout7.pdf
@@ -119,7 +119,7 @@ plan:
   materials:
   - lesson: intro/pyglet
   - title: Tahák na Pyglet
-    url: https://github.com/pyvec/cheatsheets/raw/master/pyglet/pyglet-basics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/pyglet/pyglet-basics-cs.pdf
     type: cheatsheet
   - lesson: projects/pong
     title: 'Praktické cvičení: Pong (bonus)'

--- a/runs/2017/pyladies-ostrava-jaro/info.yml
+++ b/runs/2017/pyladies-ostrava-jaro/info.yml
@@ -34,7 +34,7 @@ plan:
   - lesson: beginners/install-editor
     type: lesson
   - title: Tahák na klávesnici (PDF)
-    url: https://github.com/pyvec/cheatsheets/raw/master/keyboard/keyboard-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/keyboard/keyboard-cs.pdf
     type: cheatsheet
   - title: Instrukce a domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s001-install/handout/handout.pdf
@@ -67,7 +67,7 @@ plan:
   - lesson: intro/turtle
     type: lesson
   - title: Tahák s užitečnými funkcemi
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-functions/basic-functions-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-functions/basic-functions-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s003-looping/handout/handout3a.pdf
@@ -90,7 +90,7 @@ plan:
   - lesson: beginners/str
     type: lesson
   - title: Řetězcový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/strings/strings-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/strings/strings-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: http://pyladies.cz/v1/s004-strings/handout/handout4.pdf
@@ -122,7 +122,7 @@ plan:
   - lesson: beginners/tuple
     type: lesson
   - title: Tahák na seznamy
-    url: https://github.com/pyvec/cheatsheets/raw/master/lists/lists-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/lists/lists-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: http://pyladies.cz/v1/s006-lists/handout/handout6.pdf
@@ -136,7 +136,7 @@ plan:
   - lesson: intro/json
     type: lesson
   - title: Slovníkový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/dicts/dicts-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/dicts/dicts-cs.pdf
     type: cheatsheet
 - title: Moduly a výjimky
   slug: modules
@@ -168,7 +168,7 @@ plan:
   - title: Kód celé hry Pong
     url:  http://pyladies.cz/v1/s012-pyglet/pong.py
   - title: Tahák na Pyglet
-    url: https://github.com/pyvec/cheatsheets/raw/master/pyglet/pyglet-basics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/pyglet/pyglet-basics-cs.pdf
     type: cheatsheet
 - title: Třídy
   slug: class
@@ -185,10 +185,10 @@ plan:
   - lesson: projects/asteroids
     type: lesson
   - title: Množinový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/sets/sets-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/sets/sets-cs.pdf
     type: cheatsheet
   - title: Tahák na geometrii a fyziku 2D her
-    url: https://github.com/pyvec/cheatsheets/raw/master/game-physics/game-physics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/game-physics/game-physics-cs.pdf
     type: cheatsheet
 - title: Pokračování závěrečného projektu
   slug: asteroids2

--- a/runs/2017/pyladies-ostrava-podzim/info.yml
+++ b/runs/2017/pyladies-ostrava-podzim/info.yml
@@ -34,7 +34,7 @@ plan:
   - lesson: beginners/install-editor
     type: lesson
   - title: Tahák na klávesnici (PDF)
-    url: https://github.com/pyvec/cheatsheets/raw/master/keyboard/keyboard-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/keyboard/keyboard-cs.pdf
     type: cheatsheet
   - title: Instrukce a domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s001-install/handout/handout.pdf
@@ -67,7 +67,7 @@ plan:
   - lesson: intro/turtle
     type: lesson
   - title: Tahák s užitečnými funkcemi
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-functions/basic-functions-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-functions/basic-functions-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s003-looping/handout/handout3a.pdf
@@ -90,7 +90,7 @@ plan:
   - lesson: beginners/str
     type: lesson
   - title: Řetězcový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/strings/strings-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/strings/strings-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: http://pyladies.cz/v1/s004-strings/handout/handout4.pdf
@@ -122,7 +122,7 @@ plan:
   - lesson: beginners/tuple
     type: lesson
   - title: Tahák na seznamy
-    url: https://github.com/pyvec/cheatsheets/raw/master/lists/lists-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/lists/lists-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: http://pyladies.cz/v1/s006-lists/handout/handout6.pdf
@@ -136,7 +136,7 @@ plan:
   - lesson: intro/json
     type: lesson
   - title: Slovníkový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/dicts/dicts-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/dicts/dicts-cs.pdf
     type: cheatsheet
 - title: Moduly a výjimky
   slug: modules
@@ -168,7 +168,7 @@ plan:
   - title: Kód celé hry Pong
     url:  http://pyladies.cz/v1/s012-pyglet/pong.py
   - title: Tahák na Pyglet
-    url: https://github.com/pyvec/cheatsheets/raw/master/pyglet/pyglet-basics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/pyglet/pyglet-basics-cs.pdf
     type: cheatsheet
 - title: Třídy
   slug: class
@@ -185,10 +185,10 @@ plan:
   - lesson: projects/asteroids
     type: lesson
   - title: Množinový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/sets/sets-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/sets/sets-cs.pdf
     type: cheatsheet
   - title: Tahák na geometrii a fyziku 2D her
-    url: https://github.com/pyvec/cheatsheets/raw/master/game-physics/game-physics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/game-physics/game-physics-cs.pdf
     type: cheatsheet
 - title: Pokračování závěrečného projektu
   slug: asteroids2

--- a/runs/2017/pyladies-praha-jaro/info.yml
+++ b/runs/2017/pyladies-praha-jaro/info.yml
@@ -36,7 +36,7 @@ plan:
   - lesson: git/install
     type: lesson
   - title: Tahák na klávesnici (PDF)
-    url: https://github.com/pyvec/cheatsheets/raw/master/keyboard/keyboard-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/keyboard/keyboard-cs.pdf
     type: cheatsheet
   - title: Instrukce a domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s001-install/handout/handout.pdf
@@ -71,7 +71,7 @@ plan:
   - lesson: beginners/while
     type: lesson
   - title: Tahák s užitečnými funkcemi
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-functions/basic-functions-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-functions/basic-functions-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s003-looping/handout/handout3a.pdf
@@ -83,7 +83,7 @@ plan:
   - lesson: git/git-collaboration-2in1
     type: lesson
   - title: Gitový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-git/basic-git-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-git/basic-git-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s003-looping/handout/handout3b.pdf
@@ -97,7 +97,7 @@ plan:
   - lesson: beginners/str
     type: lesson
   - title: Řetězcový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/strings/strings-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/strings/strings-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: http://pyladies.cz/v1/s004-strings/handout/handout4.pdf
@@ -130,7 +130,7 @@ plan:
   - lesson: beginners/tuple
     type: lesson
   - title: Tahák na seznamy
-    url: https://github.com/pyvec/cheatsheets/raw/master/lists/lists-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/lists/lists-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: http://pyladies.cz/v1/s006-lists/handout-ostrava/handout6.pdf
@@ -146,7 +146,7 @@ plan:
   - lesson: projects/github-api
     type: lesson
   - title: Slovníkový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/dicts/dicts-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/dicts/dicts-cs.pdf
     type: cheatsheet
 - title: Grafika
   slug: pyglet
@@ -159,7 +159,7 @@ plan:
   - title: Kód celé hry Pong
     url: http://pyladies.cz/v1/s012-pyglet/pong.py
   - title: Tahák na Pyglet
-    url: https://github.com/pyvec/cheatsheets/raw/master/pyglet/pyglet-basics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/pyglet/pyglet-basics-cs.pdf
     type: cheatsheet
 - title: Třídy
   slug: class
@@ -176,10 +176,10 @@ plan:
   - lesson: projects/asteroids
     type: lesson
   - title: Množinový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/sets/sets-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/sets/sets-cs.pdf
     type: cheatsheet
   - title: Tahák na geometrii a fyziku 2D her
-    url: https://github.com/pyvec/cheatsheets/raw/master/game-physics/game-physics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/game-physics/game-physics-cs.pdf
     type: cheatsheet
 - title: Závěrečná procvičovací hodina
   slug: final

--- a/runs/2017/pyladies-praha-podzim-cznic/info.yml
+++ b/runs/2017/pyladies-praha-podzim-cznic/info.yml
@@ -61,7 +61,7 @@ plan:
   - lesson: git/git-collaboration-2in1
     type: lesson
   - title: Gitový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-git/basic-git-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-git/basic-git-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s003-looping/handout/handout3b.pdf

--- a/runs/2017/pyladies-praha-podzim-ntk/info.yml
+++ b/runs/2017/pyladies-praha-podzim-ntk/info.yml
@@ -61,7 +61,7 @@ plan:
   - lesson: git/git-collaboration-2in1
     type: lesson
   - title: Gitový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-git/basic-git-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-git/basic-git-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s003-looping/handout/handout3b.pdf

--- a/runs/2018/pyladies-brno-jaro-st/info.yml
+++ b/runs/2018/pyladies-brno-jaro-st/info.yml
@@ -89,7 +89,7 @@ plan:
   materials:
   - lesson: intro/pyglet
   - title: Tahák na Pyglet
-    url: https://github.com/pyvec/cheatsheets/raw/master/pyglet/pyglet-basics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/pyglet/pyglet-basics-cs.pdf
     type: cheatsheet
   - lesson: projects/pong
     title: 'Praktické cvičení: Pong (bonus)'
@@ -103,7 +103,7 @@ plan:
   - lesson: git/collaboration
   - lesson: beginners/files
   - title: Gitový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-git/basic-git-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-git/basic-git-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: http://pyladies.cz/v1/s005-modules/handout/handout7.pdf

--- a/runs/2018/pyladies-brno-jaro/info.yml
+++ b/runs/2018/pyladies-brno-jaro/info.yml
@@ -84,7 +84,7 @@ plan:
   materials:
   - lesson: intro/pyglet
   - title: Tahák na Pyglet
-    url: https://github.com/pyvec/cheatsheets/raw/master/pyglet/pyglet-basics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/pyglet/pyglet-basics-cs.pdf
     type: cheatsheet
   - title: Soubory (čtení na svátky)
     lesson: beginners/files
@@ -128,7 +128,7 @@ plan:
   materials:
   - lesson: git/collaboration
   - title: Gitový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-git/basic-git-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-git/basic-git-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: http://pyladies.cz/v1/s005-modules/handout/handout7.pdf

--- a/runs/2018/pyladies-ostrava-jaro/info.yml
+++ b/runs/2018/pyladies-ostrava-jaro/info.yml
@@ -34,7 +34,7 @@ plan:
   - lesson: beginners/install-editor
     type: lesson
   - title: Tahák na klávesnici (PDF)
-    url: https://github.com/pyvec/cheatsheets/raw/master/keyboard/keyboard-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/keyboard/keyboard-cs.pdf
     type: cheatsheet
   - title: Instrukce a domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s001-install/handout/handout.pdf
@@ -67,7 +67,7 @@ plan:
   - lesson: intro/turtle
     type: lesson
   - title: Tahák s užitečnými funkcemi
-    url: https://github.com/pyvec/cheatsheets/raw/master/basic-functions/basic-functions-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/basic-functions/basic-functions-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: https://github.com/PyLadiesCZ/pyladies.cz/raw/master/original/v1/s003-looping/handout/handout3a.pdf
@@ -90,7 +90,7 @@ plan:
   - lesson: beginners/str
     type: lesson
   - title: Řetězcový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/strings/strings-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/strings/strings-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: http://pyladies.cz/v1/s004-strings/handout/handout4.pdf
@@ -122,7 +122,7 @@ plan:
   - lesson: beginners/tuple
     type: lesson
   - title: Tahák na seznamy
-    url: https://github.com/pyvec/cheatsheets/raw/master/lists/lists-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/lists/lists-cs.pdf
     type: cheatsheet
   - title: Domácí projekty (PDF)
     url: http://pyladies.cz/v1/s006-lists/handout/handout6.pdf
@@ -136,7 +136,7 @@ plan:
   - lesson: intro/json
     type: lesson
   - title: Slovníkový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/dicts/dicts-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/dicts/dicts-cs.pdf
     type: cheatsheet
 - title: Moduly a výjimky
   slug: modules
@@ -168,7 +168,7 @@ plan:
   - title: Kód celé hry Pong
     url:  http://pyladies.cz/v1/s012-pyglet/pong.py
   - title: Tahák na Pyglet
-    url: https://github.com/pyvec/cheatsheets/raw/master/pyglet/pyglet-basics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/pyglet/pyglet-basics-cs.pdf
     type: cheatsheet
 - title: Třídy
   slug: class
@@ -185,10 +185,10 @@ plan:
   - lesson: projects/asteroids
     type: lesson
   - title: Množinový tahák
-    url: https://github.com/pyvec/cheatsheets/raw/master/sets/sets-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/sets/sets-cs.pdf
     type: cheatsheet
   - title: Tahák na geometrii a fyziku 2D her
-    url: https://github.com/pyvec/cheatsheets/raw/master/game-physics/game-physics-cs.pdf
+    url: https://pyvec.github.io/cheatsheets/game-physics/game-physics-cs.pdf
     type: cheatsheet
 - title: Pokračování závěrečného projektu
   slug: asteroids2


### PR DESCRIPTION
    sed -i 's@https://github.com/pyvec/cheatsheets/raw/master/@https://pyvec.github.io/cheatsheets/@g' $(rg -l 'https://github.com/pyvec/cheatsheets/raw/master/')

Fixes https://github.com/pyvec/naucse.python.cz/issues/324