### PR TITLE
Sort past runs by year in descending order

### DIFF
--- a/naucse/templates/run_list.html
+++ b/naucse/templates/run_list.html
@@ -33,7 +33,7 @@
     {% endfor %}
 
     <h1>Proběhlé kurzy</h1>
-    {% for year, run_year in run_years.items() %}
+    {% for year, run_year in run_years.items() | sort(reverse=True) %}
         <h2>{{ year }}</h2>
         {% for run in run_year.runs.values() | sort(attribute='start_date', reverse=True)
                 if run.end_date < today %}


### PR DESCRIPTION
The runs are sorted that way anyway, so having 2017 above 2018 doesn't make any sense.