### PR TITLE
Converted relative paths in lessons to lesson_url calls

### DIFF
--- a/lessons/beginners/class/index.md
+++ b/lessons/beginners/class/index.md
@@ -93,7 +93,7 @@ to byly funkce, a vytvořit tak nový objekt dané třídy:
 Chová se to stejně jako funkce `str`! Není to podivné?
 
 Tady se musím omluvit:
-[materiály k funkcím](../functions/)
+[materiály k funkcím]({{ lesson_url('beginners/functions') }})
 tak trochu lhaly. Funkce `str`, `int`, `float` apod. totiž vůbec
 nejsou funkce – jsou to právě třídy.
 
@@ -376,5 +376,5 @@ class Kocka:
 {% endfilter %}
 
 A to je o samotných třídách zatím vše.
-[Příště](../inheritance/) si něco řekneme o dědičnosti.
+[Příště]({{ lesson_url('beginners/inheritance') }}) si něco řekneme o dědičnosti.
 A o štěňátkách.

--- a/lessons/beginners/files/index.md
+++ b/lessons/beginners/files/index.md
@@ -203,7 +203,7 @@ with open('druha-basnicka.txt', mode='w', encoding='utf-8') as soubor:
 > Metoda `write` neodřádkovává automaticky.
 > Chceš-li do souboru zapsat více řádků, je potřeba každý z nich ukončit
 > „ručně“, speciálním znakem `'\n'` který jsme si popsal{{ gnd('i', 'y', both='i')}}
-> v [sekci o řetězcích](../str/).
+> v [sekci o řetězcích]({{ lesson_url('beginners/str') }}).
 
 Případně se dá použít funkce `print`,
 která kromě do terminálu umí vypisovat i do otevřeného souboru,

--- a/lessons/beginners/hello-world/index.md
+++ b/lessons/beginners/hello-world/index.md
@@ -29,7 +29,7 @@ print("Ahoj světe!")
 
 Pak soubor ulož pod jménem <code><span class="pythondir">~/{{ rootname }}</span>/02/ahoj.py</code>.
 Za <code class="pythondir">~/{{ rootname }}</code> musíš doplnit adresář,
-který jsi vytvořil{{a}} minule, při [instalaci Pythonu](../../beginners/install/).
+který jsi vytvořil{{a}} minule, při [instalaci Pythonu]({{ lesson_url('beginners/install') }}).
 Podadresář `02` musíš vytvořit.
 Do něj pak soubor ulož jako `ahoj.py`.
 
@@ -57,10 +57,10 @@ $ python ahoj.py
 
 > [note]
 > S příkazovou řádkou jsme se seznámil{{gnd('i', 'y', both='i')}}
-> v [minulé lekci](../../beginners/cmdline/), která popisuje i změnu aktuálního
+> v [minulé lekci]({{ lesson_url('beginners/cmdline') }}), která popisuje i změnu aktuálního
 > adresáře pomocí příkazu `cd`.
 > Aktivaci virtuálního prostředí jsme probral{{gnd('i', 'y', both='i')}} společně
-> s [instalací Pythonu](../../beginners/install/).
+> s [instalací Pythonu]({{ lesson_url('beginners/install') }}).
 
 > [note] Poznámka pro Windows a starší Python
 > V nečeských Windows s Pythonem 3.5 či nižším bude třeba před

--- a/lessons/beginners/inheritance/index.md
+++ b/lessons/beginners/inheritance/index.md
@@ -273,4 +273,4 @@ z ní dědit má.
 A to je zatím o třídách vše. Už toho víš dost na to,
 aby sis napsal{{a}} vlastní zoo :)
 
-Nebo [hru](../../projects/asteroids/)?
+Nebo [hru]({{ lesson_url('projects/asteroids') }})?

--- a/lessons/git/git-collaboration-2in1/index.md
+++ b/lessons/git/git-collaboration-2in1/index.md
@@ -62,7 +62,7 @@ jen Gitu řekneme, že z něj chceme ten repozitář udělat. To má za následe
 3. Můžeme nastavit vzdálené repozitáře, kam chceme změny nahrávat nebo naopak stahovat změny od jiných lidí. 
 
 > [note] Pozor
-> Budeme hodně pracovat s příkazovou řádkou. Jestli se s ní ještě nekamarádíš, koukni se na [úvod](../../beginners/cmdline/).
+> Budeme hodně pracovat s příkazovou řádkou. Jestli se s ní ještě nekamarádíš, koukni se na [úvod]({{ lesson_url('beginners/cmdline') }}).
 > Nezapomeň: $ na začátku se nepíše; je tu proto, aby šlo poznat, že jde o příkaz.
 
 Naším dnešním cílem je ale přispět do projektu, který založil někdo jiný. Proto použijeme příkaz `git clone` ke stažení vzdáleného repozitáře.

--- a/lessons/intro/async/index.md
+++ b/lessons/intro/async/index.md
@@ -24,7 +24,7 @@ $ python -m pip install aiohttp
 ---
 
 > [note]
-> V minulosti byly na této stránce popsány i [generátory](../../advanced/generators/).
+> V minulosti byly na této stránce popsány i [generátory]({{ lesson_url('advanced/generators') }}).
 > Neovládáte-li je ještě, přečtěte si o nich.
 {% endif %}
 
@@ -37,7 +37,7 @@ AsyncIO
 Pojďme si povídat o souběžnosti – možnostech, jak nechat počítač dělat víc
 úloh věcí najednou.
 
-Jak jsme si řekli v [lekci o C API](../cython/), Python má globální zámek, takže pythonní kód
+Jak jsme si řekli v [lekci o C API]({{ lesson_url('intro/cython') }}), Python má globální zámek, takže pythonní kód
 může běžet jen v jednom vlákně najednou.
 Taky jsme si řekli, že to většinou příliš nevadí: typický síťový nebo GUI program
 stráví hodně času čekáním na události (odpověď z internetu, kliknutí myší atp.)

--- a/lessons/intro/deployment/index.md
+++ b/lessons/intro/deployment/index.md
@@ -6,7 +6,7 @@ Existují různé možnosti, jednou z nich je nasadit ji do cloudu.
 
 > [note]
 > Nemáte ještě webovou aplikaci? Můžete vyzkoušet framework
-> [Flask](../../intro/flask/).
+> [Flask]({{ lesson_url('intro/flask') }}).
 
 ### WSGI
 

--- a/lessons/intro/flask/index.md
+++ b/lessons/intro/flask/index.md
@@ -71,7 +71,7 @@ Tomuto spojení cesty a pohledové funkce se říká *route* (nebo počeštěně
 My konkrétně říkáme, že na cestě `/` (tedy na „domovské stránce“) bude
 k dispozici obsah, který vrátí funkce `index`.
 
-[URL]: ../../fast-track/http/#url-anatomy
+[URL]: {{ lesson_url('fast-track/http') }}#url-anatomy
 
 Více různých adres lze obsloužit jednoduše přidáním dalších funkcí:
 

--- a/lessons/intro/numpy/index.ipynb
+++ b/lessons/intro/numpy/index.ipynb
@@ -22,7 +22,7 @@
     "* [sample.wav](static/sample.wav)\n",
     "* [secret.png](static/secret.png)\n",
     "\n",
-    "A až bude nainstalováno, spusťte si nový Notebook. (Viz [lekce o Notebooku](../notebook/).)"
+    "A až bude nainstalováno, spusťte si nový Notebook. (Viz [lekce o Notebooku]({{ lesson_url('intro/notebook') }}).)"
    ]
   },
   {

--- a/lessons/intro/pandas/index.ipynb
+++ b/lessons/intro/pandas/index.ipynb
@@ -18,7 +18,7 @@
     "[actors.csv](static/actors.csv) a\n",
     "[spouses.csv](static/spouses.csv).\n",
     "\n",
-    "A až bude nainstalováno, spusťte si nový Notebook. (Viz [lekce o Notebooku](../notebook/).)\n",
+    "A až bude nainstalováno, spusťte si nový Notebook. (Viz [lekce o Notebooku]({{ lesson_url('intro/notebook') }}).)\n",
     "\n",
     "---"
    ]
@@ -69,7 +69,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Jak bylo řečeno u [NumPy](../numpy/), analytici – cílová skupina této knihovny – mají rádi zkratky. Ve spoustě materiálů na Webu proto najdete `import pandas as pd`, případně rovnou (a bez vysvětlení) použité `pd` jako zkratku pro `pandas`. Tento návod ale používá plné jméno."
+    "Jak bylo řečeno u [NumPy]({{ lesson_url('intro/numpy') }}), analytici – cílová skupina této knihovny – mají rádi zkratky. Ve spoustě materiálů na Webu proto najdete `import pandas as pd`, případně rovnou (a bez vysvětlení) použité `pd` jako zkratku pro `pandas`. Tento návod ale používá plné jméno."
    ]
   },
   {

--- a/lessons/intro/pyqt/index.md
+++ b/lessons/intro/pyqt/index.md
@@ -163,7 +163,7 @@ ho „nevlastníte“ i ve smyslu C++/Qt.
 
 Občas se stane, že program spadne pro chybu jako nepovolený přístup do paměti.
 Bez hlubší znalosti Qt a PyQt se taková chyba odstraňuje poměrně těžko, ale vaše znalosti C++ (z jiných kurzů)
-a CPython C API (z [minula](../cython/)) vám v tom pomůžou.
+a CPython C API (z [minula]({{ lesson_url('intro/cython') }})) vám v tom pomůžou.
 Doporučujeme dělat malé commity a psát jednoduchý kód.
 
 ### Smyčka událostí, signály a sloty
@@ -357,7 +357,7 @@ Vlastní widget - Grid
 
 Qt neobsahuje předpřipravený widget na dlaždicové mapy. Musíme si tedy vyrobit vlastní.
 
-Mapu budeme reprezentovat jako NumPy matici (viz [lekce o NumPy](../numpy/)).
+Mapu budeme reprezentovat jako NumPy matici (viz [lekce o NumPy]({{ lesson_url('intro/numpy') }})).
 Zatím budeme používat dva druhy dlaždic: trávu (v matici reprezentovanou jako 0) a zeď (-1).
 
 Velikost widgetu se zadává v pixelech. Musíme ho udělat dostatečně velký, aby se do něj vešla všechna políčka mapy.

--- a/lessons/intro/testing/index.md
+++ b/lessons/intro/testing/index.md
@@ -142,7 +142,7 @@ def test_xmas(year):
 
 ```
 
-Zápis je určitým způsobem podobný knihovně [click](../click/): funkce
+Zápis je určitým způsobem podobný knihovně [click]({{ lesson_url('intro/click') }}): funkce
 s testem přijímá parametr vytvořený v dekorátoru.
 Test se spustí pro každou uvedenou hodnotu, k jejich definici lze použít
 jakýkoliv objekt, přes který jde iterovat, tedy kromě v ukázce použité
@@ -437,7 +437,7 @@ použijí při testech. V zásadě to funguje takto:
  * Pokud daný HTTP požadavek ještě neproběhl, provede se a nahraje na kazetu.
  * Pokud již proběhl, použije se daná kazeta pro simulaci.
 
-Betamax funguje pouze s knihovnou [requests](../requests/) při použití session.
+Betamax funguje pouze s knihovnou [requests]({{ lesson_url('intro/requests')}}) při použití session.
 
 V kombinaci s pytestem můžete použít předpřipravenou fixture:
 

--- a/lessons/projects/asteroids/index.md
+++ b/lessons/projects/asteroids/index.md
@@ -198,7 +198,7 @@ Přidej druhý typ vesmírného objektu: `Asteroid`.
   vesmírné objekty (např. věci kolem zrychlení);
   část bude specifická jen pro raketku (ovládání
   pomocí klávesnice).
-  Využij funkci `super()` z [lekce o dědičnosti](../../beginners/inheritance/).
+  Využij funkci `super()` z [lekce o dědičnosti]({{ lesson_url('beginners/inheritance') }}).
 * Napiš ještě třídu `Asteroid`,
   která taky dědí ze `SpaceObject`,
   ale má svoje vlastní chování:


### PR DESCRIPTION
I think that's all of them if I'm searching correctly.

I replaced these in a previous version of my thesis implementation, it's not particularly important for me anymore, however it could fix some builds until #341 is implemented, so I'm committing it separately, so if you want to merge it, go ahead.