### PR TITLE
Limited the usage of custom css to a specific div

### DIFF
--- a/naucse/static/css/nausce.css
+++ b/naucse/static/css/nausce.css
@@ -91,6 +91,11 @@ a:hover {
     text-decoration: none;
 }
 
+.lesson-content {
+    /* So elements inside with `position: absolute` are positioned absolutely just inside this div. */
+    position: relative;
+}
+
 
 .lesson-header {
     line-height: 1.5rem;

--- a/naucse/templates/lesson.html
+++ b/naucse/templates/lesson.html
@@ -29,9 +29,11 @@
             </header>
         {% endif %}
 
-        {% block lesson_content %}
-            {{ content }}
-        {% endblock %}
+        <div class="lesson-content">
+            {% block lesson_content %}
+                {{ content }}
+            {% endblock %}
+        </div>
 
         {% if (prv is defined and prv != None) or (nxt is defined and nxt != None) %}
         <hr class="lesson-end">

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pygments
 python-dateutil
 traitlets
 werkzeug
+cssutils


### PR DESCRIPTION
My thesis implementation includes limiting CSS from forks to only the content of the lesson itself, this is a preparation for that, so the diff is manageable.