### PR TITLE
Add Lumír's MicroPython workshop as link to external repo

### DIFF
--- a/runs/2018/micropython-workshop-ostrava/link.yml
+++ b/runs/2018/micropython-workshop-ostrava/link.yml
@@ -1,0 +1,2 @@
+repo: https://github.com/frenzymadness/naucse.python.cz.git
+branch: micropython-workshop-ostrava


### PR DESCRIPTION
This should work as if https://github.com/pyvec/naucse.python.cz/pull/395 was merged