### PR TITLE
Change base_url and all absolute naucse links to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Otevřené materiály pro výuku Pythonu – jak na organizovaných kurzech,
 tak pro samouky.
 
-Dostupné na [naucse.python.cz](http://naucse.python.cz).
+Dostupné na [naucse.python.cz](https://naucse.python.cz).
 
 
 ## Instalace a spuštění
@@ -12,7 +12,7 @@ Chceš-li server spustit na svém počítači, např. proto, že se chceš zapoj
 nebo abys ho měl/a k dispozici i bez připojení k Intenetu, je potřeba ho
 nejdřív nainstalovat:
 
-* Vytvoř a aktivuj si [virtuální prostředí](http://naucse.python.cz/lessons/beginners/install/) v Pythonu 3.6.
+* Vytvoř a aktivuj si [virtuální prostředí](https://naucse.python.cz/lessons/beginners/install/) v Pythonu 3.6.
 * Přepni se do adresáře s kódem projektu.
 * Nainstaluj závislosti:
    ```console

--- a/lessons/meta/submitting-a-run/index.md
+++ b/lessons/meta/submitting-a-run/index.md
@@ -1,6 +1,6 @@
 # Přidání kurzu na Nauč se Python
 
-Když už máme nadefinováný vlastní kurz, zbývá nám jen ho dostat na [naucse.python.cz](http://naucse.python.cz/).
+Když už máme nadefinováný vlastní kurz, zbývá nám jen ho dostat na [naucse.python.cz](https://naucse.python.cz/).
 Budeme k tomu potřebovat jen pár příkazu v Gitu a trochu trpělivosti.
 
 ## Nahrání do vlastního forku
@@ -83,7 +83,7 @@ Teď už potřebuješ udělat _Pull Request_ (dále jen jako PR) se souborem `li
 Jak udělat PR je popsáno v [návodu na používání Gitu]({{lesson_url("git/git-collaboration-2in1")}}).
 Ideálně do popisku napiš, kdo jsi a co organizuješ za kurz, ať to správci nemusí zjišťovat například z popisku v `info.yml`.
 
-Po tom, co správci PR schválí a sloučí tvoje změny do základního repozitáře, stačí počkat pár minut a tvůj kurz se objeví na [naucse.python.cz](http://naucse.python.cz/).
+Po tom, co správci PR schválí a sloučí tvoje změny do základního repozitáře, stačí počkat pár minut a tvůj kurz se objeví na [naucse.python.cz](https://naucse.python.cz/).
 
 ## Upravování kurzu
 
@@ -99,7 +99,7 @@ S každou změnou pak musíš udělat commit a odeslat commit na GitHub.
 
 Už naprosto poslední věc, kterou je potřeba zařídit, je aby se změny ve tvém kurzu u tebe ve forku projevily na Nauč se.
 To se dělá pomocí tzv. webhooků, webových adres, které reagují na nějaké akce.
-Musíš tedy nastavit svůj fork, aby posílal akce na webhook, který vyvolá nové nasazení webové stránky [naucse.python.cz](http://naucse.python.cz/).
+Musíš tedy nastavit svůj fork, aby posílal akce na webhook, který vyvolá nové nasazení webové stránky [naucse.python.cz](https://naucse.python.cz/).
 
 Pro instalaci webhooků máme speciální aplikaci, která je umí sama nastavit.
 Běží na adrese [hooks.nauc.se](https://hooks.nauc.se).

--- a/naucse/__init__.py
+++ b/naucse/__init__.py
@@ -40,4 +40,4 @@ def main():
     # see the generator for details
     freezer.register_generator(lesson_static_generator)
 
-    cli(app, base_url='http://naucse.python.cz', freezer=freezer)
+    cli(app, base_url='https://naucse.python.cz', freezer=freezer)


### PR DESCRIPTION
Fixes https://github.com/pyvec/naucse.python.cz/issues/380

Links in [fast-track/http](https://naucse.python.cz/lessons/fast-track/http/) are left intact to keep the content simple and not to deal with HTTPS internals.