### PR TITLE
Fixed test_runs_page to get all the runs, not just the recent ones

### DIFF
--- a/test_naucse/test_forks.py
+++ b/test_naucse/test_forks.py
@@ -343,7 +343,7 @@ def test_runs_page(mocker, client: FlaskClient):
 
     # unless problems are silenced
     mocker.patch("naucse.utils.views.raise_errors_from_forks", lambda: False)
-    response = client.get("/runs/")
+    response = client.get("/runs/all/")
     assert b"Broken run title" not in response.data
 
     # but working forks are still present


### PR DESCRIPTION
Fixes the broken build in master, only `/runs/` was requested but that only includes recent runs...