### PR TITLE
Explicit encoding for opening files

### DIFF
--- a/naucse/models.py
+++ b/naucse/models.py
@@ -175,7 +175,7 @@ class Page(Model):
             template = self._get_template()
             content = template.render(**kwargs)
         else:
-            with self.path.open() as file:
+            with self.path.open(encoding="utf-8") as file:
                 content = file.read()
 
         def convert_url(url):
@@ -435,7 +435,7 @@ class Session(Model):
         q = self.path / 'sessions' / self.slug / coverpage
 
         try:
-            with q.open() as f:
+            with q.open(encoding="utf-8") as f:
                 md_content = f.read()
         except FileNotFoundError:
             return ""


### PR DESCRIPTION
So we ran into a problem in #420, where a session coverpage with a custom content failed to render because of a ``UnicodeDecodeError``. 

This was doubly weird because up until now it wasn't failing, and even on my pc when Docker wasn't involved everything worked fine. So I investigated further and found out that the default locale in Docker, the locale that is used by default by ``open`` when encoding is not set, is set to ``ANSI_X3.4-1968``.

Ideally the locale in Docker would be ``UTF-8``, as any sensible person would expect, but this solution is much quicker. I did create an issue for that in Arca and it can be solved in the future (https://github.com/mikicz/arca/issues/46).