### PR TITLE
Style <kbd> elements more like keyboard buttons.

### DIFF
--- a/naucse/static/css/body.css
+++ b/naucse/static/css/body.css
@@ -13,10 +13,14 @@ hr.lesson-end {
 }
 
 p kbd {
-    background-color: #DDD;
-    border: 1px solid black;
+    background-color: #f5f5f5;
+    border: 1px solid #ccc;
+    border-bottom-width: 3px;
+    border-radius: 3px;
     color: black;
     font-style: normal;
+    padding-bottom: 0;
+    box-shadow:inset 0px 1px 0px 0px #fff;
 }
 
 /*** Credits ***/


### PR DESCRIPTION
Screenshot of the new look on naucse: 

![kbd](https://user-images.githubusercontent.com/302922/44794554-06667200-aba9-11e8-9c37-03666d019ce5.png)

---

How the `<kbd>` tag is rendered in a GitHub comment: <kbd>Enter</kbd>
