### PR TITLE
Modify CSS pre+code font to fix asciiart diagrams

### DIFF
--- a/naucse/static/css/naucse.css
+++ b/naucse/static/css/naucse.css
@@ -156,7 +156,6 @@ pre {
     border-radius: 4px;
     color: #333;
     display: block;
-    font-family: monospace;
     font-size: 13px;
     line-height: 1.42857143;
     margin: 0 0 10px;
@@ -171,7 +170,6 @@ code {
     border-radius: 4px;
     background-color: #f9f2f4;
     color: #c7254e;
-    font-family: monospace;
     font-size: 90%;
     padding: 2px 4px;
     white-space: pre-wrap;


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/115487/46369363-0a435380-c683-11e8-8b5d-f7991d478b7b.png)

After:

![image](https://user-images.githubusercontent.com/115487/46369384-14fde880-c683-11e8-8753-9cbdb58d56fb.png)