### PR TITLE
Simplify the Files lesson

### DIFF
--- a/lessons/beginners/files/index.md
+++ b/lessons/beginners/files/index.md
@@ -3,11 +3,6 @@
 Dnes se podíváme na to, jak v Pythonu číst z
 (a pak i zapisovat do) souborů.
 
-Ke čtení textu ze souboru jsou potřeba tři kroky:
-* soubor *otevřít*,
-* něco z něj *přečíst*
-* a pak jej zase *zavřít*.
-
 Vytvoř si v editoru soubor `basnicka.txt` a napiš do něj libovolnou básničku.
 Soubor ulož.
 
@@ -33,10 +28,10 @@ Potom napiš tento program:
 ```python
 soubor = open('basnicka.txt', encoding='utf-8')
 obsah = soubor.read()
-print(obsah)
 soubor.close()
-```
 
+print(obsah)
+```
 a spusť ho z adresáře, ve kterém je
 `basnicka.txt` (jinými slovy, aktuální adresář musí být ten, který
 obsahuje soubor s básničkou).
@@ -49,7 +44,45 @@ Tak jako `int()` vrací čísla a `input()` řetězce, funkce
 Tahle hodnota má vlastní metody.
 Tady používáme metodu `read()`, která
 najednou přečte celý obsah souboru a vrátí ho jako řetězec.
-Na metodu `close()`, která otevřený soubor zavírá, se podíváme později.
+Nakonec metoda `close()` otevřený soubor zase zavře.
+
+
+## Automatické zavírání souborů
+
+Soubory se dají přirovnat k ledničce: abys něco
+mohl{{a}} z ledničky vzít, nebo dát dovnitř, musíš
+ji předtím otevřít a potom zavřít.
+Bez zavření to sice na první pohled funguje taky,
+ale pravděpodobně potom brzo něco zplesniví.
+
+Stejně tak je docela důležité soubor zavřít po tom,
+co s ním přestaneš pracovat.
+Bez zavření to na první pohled funguje, ale složitější programy se můžou dostat
+do problémů.
+Operační systémy mají limity na počet
+současně otevřených souborů, které se nezavíráním
+dají snadno překročit.
+Na Windows navíc nemůžeš soubor, který je stále
+otevřený, otevřít znovu.
+
+Na korektní zavření souboru ale programátoři často zapomenou.
+Proto Python poskytuje příkaz `with`, který soubory zavírá automaticky.
+Používá se takhle:
+
+```python
+with open('basnicka.txt', encoding='utf-8') as soubor:
+    obsah = soubor.read()
+
+print(obsah)
+```
+
+Příkaz `with` vezme otevřený soubor (který vrací funkce `open`)
+a přiřadí ho do proměnné `soubor`.
+Pak následuje odsazený blok kódu, kde se souborem můžeš pracovat – v tomhle
+případě pomocí metody `read` přečíst obsah jako řetězec.
+Když se Python dostane na konec odsazeného bloku, soubor automaticky zavře.
+
+V naprosté většině případů je pro otevírání souborů nejlepší použít `with`.
 
 
 ## Iterace nad soubory
@@ -60,16 +93,17 @@ Tak jako `for i in range` poskytuje za sebou jdoucí čísla a `for c in 'abcd'`
 poskytuje jednotlivé znaky řetězce, `for radek in soubor` bude do proměnné
 `radek` dávat jednotlivé řádky čtené ze souboru.
 
-Například můžeme básničku odsadit,
+Například můžeš básničku odsadit,
 aby se vyjímala v textu:
 
 ```python
 print('Slyšela jsem tuto básničku:')
 print()
-soubor = open('basnicka.txt', encoding='utf-8')
-for radek in soubor:
-    print('    ' + radek)
-soubor.close()
+
+with open('basnicka.txt', encoding='utf-8') as soubor:
+    for radek in soubor:
+        print('    ' + radek)
+
 print()
 print('Jak se ti líbí?')
 ```
@@ -79,13 +113,11 @@ Když to zkusíš, zjistíš, že trochu nesedí
 řádkování. Zkusíš vysvětlit, proč tomu tak je?
 
 {% filter solution %}
-Každý řádek končí znakem nového řádku (`'\n'`).
-Při procházení souboru Python tento znak nechává na konci řetězce
-`radek` ¹.
+Každý řádek končí znakem nového řádku, `'\n'`,
+který možná znáš ze [sekce o řetězcích](../str/).
+Při procházení souboru Python tento znak nechává na konci řetězce `radek` ¹.
 Funkce `print` pak přidá další nový řádek, protože ta na konci
 výpisu vždycky odřádkovává – pokud nedostane argument `end=''`.
-To je jeden způsob jak řádkování „spravit“; další je použít na každý řádek
-metodu `rstrip`, která odstraní mezery a nové řádky z konce řetězce.
 
 ---
 
@@ -95,85 +127,22 @@ končí na `'\n'`
 
 {% endfilter %}
 
+Ideální způsob, jak odřádkování spravit, je odstranit z konce řetězce
+bílé znaky (mezery a nové řádky) pomocí metody `rstrip`:
 
-## Zavírání souborů
-
-Je docela důležité soubor potom, co s ním
-přestaneš pracovat, zavřít (pomocí metody `close()`).
-Operační systémy mají limity na počet
-současně otevřených souborů, které se nezavíráním
-dají snadno překročit.
-Na Windows navíc nemůžeš soubor, který je stále
-otevřený, otevřít znovu.
-
-Soubory se dají přirovnat k ledničce: abychom něco
-mohly z ledničky vzít, nebo dát dovnitř, musíme
-ji předtím otevřít a potom zavřít.
-Bez zavření to sice na první pohled funguje taky,
-ale pravděpodobně potom brzo něco zplesniví.
-
-
-Zapomenout zavřít soubor je docela jednoduché:
-například pokud by v rámci zpracování souboru
-nastala výjimka nebo kdybys vyskočila z funkce
-pomocí `return`, náš předchozí kód by `close` nezavolal,
-a soubor by zůstal otevřený.
-
-K tomu, abychom soubor nezapomněl{{gnd('i', 'y', both='i')}} v podobných
-příkazech zavřít, slouží příkaz
-`try/finally`, který jsme si ukázal{{gnd('i', 'y', both='i')}} v souvislosti
-s výjimkami.
-
-Pro připomenutí, `finally` se provede vždycky – i když blok `try` skončí
-normálně, i když v něm nastane výjimka, i když z něj
-„vyskočíš” pomocí `return` či `break`.
 
 ```python
-def iniciala():
-    """Vrátí první písmeno v daném souboru."""
+print('Slyšela jsem tuto básničku:')
+print()
 
-    soubor = open('basnicka.txt', encoding='utf-8')
-    try:
-        obsah = soubor.read()
-        return obsah[0]
-    finally:
-        soubor.close()
+with open('basnicka.txt', encoding='utf-8') as soubor:
+    for radek in soubor:
+        radek = radek.rstrip()
+        print('    ' + radek)
 
-print(iniciala())
+print()
+print('Jak se ti líbí?')
 ```
-
-Blok `finally` se takhle dá použít vždycky,
-když je potřeba něco ukončit nebo zavřít – ať už
-je to soubor, nebo třeba připojení k databázi.
-
-
-## Příkaz with
-
-Protože je `try/finally` celkem dlouhé a nepohodlné, má Python i příjemnější
-variantu, příkaz `with`:
-
-```python
-def iniciala():
-    """Vrátí první písmeno v daném souboru."""
-
-    with open('basnicka.txt', encoding='utf-8') as soubor:
-        obsah = soubor.read()
-        return obsah[0]
-
-print(iniciala())
-```
-Tenhle příkaz jsme už viděl{{gnd('i', 'y', both='i')}} u testování,
-kde uvozoval blok, ve kterém má nastat výjimka –
-potom, co blok skončí, se zkontroluje, jestli
-nastala a jestli je toho správného typu.
-V našem případě se po skončení bloku
-zavře soubor, ať už výjimka nastala nebo ne.
-Podobně jako s `finally` se zavře vždycky
-– ať už blok `with` skončil normálně,
-výjimkou, nebo, jako tady, „vyskočením” ven.
-
-V naprosté většině případů je pro práci se soubory
-nejlepší použít `with`.
 
 
 ## Psaní souborů
@@ -184,33 +153,14 @@ nejlepší použít `with`.
 > důležité informace!
 
 Soubory se v Pythonu dají i zapisovat.
-Pro zápis se soubor otevře pomocí pojmenovaného
-argumentu `mode='w'` (z angl.
-*mode*, mód a *write*, psát).
-Zapisovat jednotlivé řetězce se pak dá metodou
-`write`.
+Pro zápis soubor otevři s pojmenovaným
+argumentem `mode='w'` (z angl. *mode*, mód a *write*, psát).
 
 Pokud soubor už existuje, otevřením s `mode='w'` se veškerý jeho obsah smaže.
 Po zavření tak v souboru bude jen to, co do něj ve svém programu zapíšeš.
 
-```python
-with open('druha-basnicka.txt', mode='w', encoding='utf-8') as soubor:
-    soubor.write('Naše staré hodiny\n')
-    soubor.write('Bijí čtyři hodiny\n')
-```
-
-> [note] Proč to \n?
-> Metoda `write` neodřádkovává automaticky.
-> Chceš-li do souboru zapsat více řádků, je potřeba každý z nich ukončit
-> „ručně“, speciálním znakem `'\n'` který jsme si popsal{{ gnd('i', 'y', both='i')}}
-> v [sekci o řetězcích](../str/).
-
-Případně se dá použít funkce `print`,
-která kromě do terminálu umí vypisovat i do otevřeného souboru,
-a to pomocí pojmenovaného argumentu `file`.
-Ostatní možnosti funkce `print` – automatické odřádkování,
-převádnění na řetězce, možnost vypsat víc
-hodnot najednou apod. – samozřejmě zůstávají.
+Informace pak do souboru zapiš známou funkcí `print`,
+a to s pojmenovaným argumentem `file`:
 
 ```python
 with open('druha-basnicka.txt', mode='w', encoding='utf-8') as soubor:


### PR DESCRIPTION
The original lesson goes through some detours in an attempt to cover
all the bases and explain things from first principles. That makes it
unnecessarily hard to teach, and learn.

- Avoid mentioning try/finally and file.write().
- Show the `with` command earlier