### PR TITLE
Smaller output changes

### DIFF
--- a/naucse/templates/_base.html
+++ b/naucse/templates/_base.html
@@ -61,30 +61,12 @@
                     </p>
                 {% endif %}
 
-                {% if page is defined and (page.attributions or page.license) %}
-                    {% for a in page.attributions %}
-                        {{ a | markdown }}
-                    {% endfor %}
-                    <p>
-                        Licence:
-                        <a href="{{ page.license.url }}">
-                            {{ page.license.title }}
-                        </a>
-                        {% if page.license_code %}
-                    </p>
-                    <p>
-                        Licence ukázek kódu:
-                        <a href="{{ page.license_code.url }}">
-                            {{ page.license_code.title }}
-                        </a>
-                        {% endif %}
-                    </p>
-                {% else %}
+                {% block attributions %}{% endblock %}
+                {% block license %}
                     <p>
                         Licence: <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International</a> není-li uvedeno jinak
                     </p>
-                {% endif %}
-
+                {% endblock license %}
                 {% block extra_footer %}{% endblock %}
             </div>
         </div>

--- a/naucse/templates/lesson.html
+++ b/naucse/templates/lesson.html
@@ -33,3 +33,26 @@
     {{ content|safe }}
 
 {% endblock %}
+
+{% block attributions %}
+    {% for a in page.attributions %}
+        {{ a | markdown }}
+    {% endfor %}
+{% endblock %}
+
+{% block license %}
+    <p>
+        Licence:
+        <a href="{{ page.license.url }}">
+            {{ page.license.title }}
+        </a>
+    </p>
+    {% if page.license_code %}
+        <p>
+            Licence ukázek kódu:
+            <a href="{{ page.license_code.url }}">
+                {{ page.license_code.title }}
+            </a>
+        </p>
+    {% endif %}
+{% endblock license %}

--- a/naucse/views.py
+++ b/naucse/views.py
@@ -382,7 +382,7 @@ def get_footer_links(course, session, prv, nxt, lesson_url):
     if prv is not None:
         prev_link = {
             "url": lesson_url(prv.page.lesson, page=prv.page.slug),
-            "title": prv.page.title,
+            "title": prv.title,
         }
 
     session_link = None
@@ -396,7 +396,7 @@ def get_footer_links(course, session, prv, nxt, lesson_url):
     if nxt is not None:
         next_link = {
             "url": lesson_url(nxt.page.lesson, page=nxt.page.slug),
-            "title": nxt.page.title,
+            "title": nxt.title,
         }
     elif session is not None:
         next_link = {

--- a/naucse/views.py
+++ b/naucse/views.py
@@ -864,6 +864,7 @@ def generate_calendar_ics(course):
         else:
             raise ValueError("One of the sessions doesn't have a start time.")
 
+        created = os.environ.get('NAUCSE_CALENDAR_DTSTAMP', None)
         cal_event = ics.Event(
             name=session.title,
             begin=start_time,
@@ -872,6 +873,7 @@ def generate_calendar_ics(course):
                         course=course,
                         session=session.slug,
                         _external=True),
+            created=created,
         )
         events.append(cal_event)
 


### PR DESCRIPTION
I'm [refactoring](https://github.com/pyvec/naucse.python.cz/issues/494) the model with the same output as before. So, if I need to make any any changes to the output, I'll make them here as well.
Here's the first batch.

## Use material title, not the (generic) page title, in prev/next links

For example, the back link in [2018/czechitas-ostrava-jaro/beginners/functions/](https://naucse.python.cz/2018/czechitas-ostrava-jaro/beginners/functions/) is labeled “Nebo anebo a”, but the [lesson list](https://naucse.python.cz/2018/czechitas-ostrava-jaro/sessions/loops/) shows “\*Nebo\* anebo \*a\* (bonus)“.
Use the title in the lesson list.

## Move page-specific blocks (attribution, license) to the page template 

The logic for these block is quite complicated. This commit makes them a *little* more sane. Changes should be whitespace-only.

## Add environment variable for creating reproducible iCal timestamps

iCal DTSTAMP entries change with every deploy; this adds a possibility to make them stable.
