### PR TITLE
Unify CSS sanitization for page style and <style> tags

### DIFF
--- a/naucse/models.py
+++ b/naucse/models.py
@@ -18,6 +18,7 @@ from naucse.sanitize import sanitize_html
 from naucse.templates import setup_jinja_env, vars_functions
 from naucse.utils.markdown import convert_markdown
 from naucse.utils.notebook import convert_notebook
+from naucse.sanitize import sanitize_css
 from pathlib import Path
 
 
@@ -91,7 +92,7 @@ class Page(Model):
         if css is None:
             return None
 
-        return self.limit_css_to_lesson_content(css)
+        return sanitize_css(css)
 
     @reify
     def edit_path(self):
@@ -195,23 +196,6 @@ class Page(Model):
             return content
         else:
             return solutions[solution]
-
-    @staticmethod
-    def limit_css_to_lesson_content(css):
-        """Return ``css`` limited just to the ``.lesson-content`` element.
-
-        This doesn't protect against malicious input.
-        """
-        parser = cssutils.CSSParser(raiseExceptions=True)
-        parsed = parser.parseString(css)
-
-        for rule in parsed.cssRules:
-            for selector in rule.selectorList:
-                # the space is important - there's a difference between for example
-                # ``.lesson-content:hover`` and ``.lesson-content :hover``
-                selector.selectorText = ".lesson-content " + selector.selectorText
-
-        return parsed.cssText.decode("utf-8")
 
 
 class Collection(Model):

--- a/naucse/utils/links.py
+++ b/naucse/utils/links.py
@@ -3,7 +3,7 @@
 from xml.dom import SyntaxErr
 
 from naucse.models import Page
-from naucse.sanitize import DisallowedStyle
+from naucse.sanitize import DisallowedStyle, sanitize_css
 
 
 class InvalidInfo(Exception):
@@ -68,7 +68,7 @@ def process_page_data(page):
 
     if page["css"]:
         try:
-            Page.limit_css_to_lesson_content(page["css"])
+            page["css"] = sanitize_css(page["css"])
         except SyntaxErr:
             raise DisallowedStyle(DisallowedStyle.COULD_NOT_PARSE)
 


### PR DESCRIPTION
This prepends `.lesson-content ` to CSS rules coming from forks.
Previously we *either* did that or limited CSS`.dataframe` (e.g. Pandas tables), depending on where the CSS came from.