### PR TITLE
Přidej ostravský jarní běh roku 2019

### DIFF
--- a/runs/2019/pyladies-ostrava-jaro/link.yml
+++ b/runs/2019/pyladies-ostrava-jaro/link.yml
@@ -1,0 +1,2 @@
+repo: https://github.com/PyLadiesCZ/naucse.python.cz.git
+branch: spring2019


### PR DESCRIPTION
Přidán nový běh pro ostravské jaro roku 2019. Jedná se o odkaz na větev v odnoži PyLadiesCZ.

Odkaz zatím nebude fungovat. Až po začlenení žádosti https://github.com/PyLadiesCZ/naucse.python.cz/pull/19.