### PR TITLE
pipenv: Set environment variables via .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PYTHONPATH=.

--- a/Pipfile
+++ b/Pipfile
@@ -4,9 +4,9 @@ verify_ssl = true
 name = "pypi"
 
 [scripts]
-naucse = "env PYTHONPATH=. python -m naucse"
-serve = "env PYTHONPATH=. python -m naucse serve"
-freeze = "env PYTHONPATH=. python -m naucse freeze"
+naucse = "python -m naucse"
+serve = "python -m naucse serve"
+freeze = "python -m naucse freeze"
 test = "python -m pytest test_naucse/"
 
 [packages]


### PR DESCRIPTION
(Maybe) fixes https://github.com/pyvec/naucse.python.cz/issues/515

This works on Linux. I have not tested it on Windows and I have no idea if it works there.
If anyone would be able to check that, it would be great.