### PR TITLE
Ostrava: Add link to Git workshop materials

### DIFF
--- a/runs/2019/ostrava-git-workshop/link.yml
+++ b/runs/2019/ostrava-git-workshop/link.yml
@@ -1,0 +1,2 @@
+repo: https://github.com/frenzymadness/naucse.python.cz.git
+branch: ostrava_git_workshop


### PR DESCRIPTION
Content source can be found here: https://github.com/frenzymadness/naucse.python.cz/tree/ostrava_git_workshop