### PR TITLE
Add a separate lesson on string templates: f-strings and `format`

### DIFF
--- a/courses/pyladies/info.yml
+++ b/courses/pyladies/info.yml
@@ -58,6 +58,7 @@ plan:
   materials:
   - lesson: beginners/def
   - lesson: beginners/str
+  - lesson: beginners/fstring
   - title: Řetězcový tahák
     url: https://pyvec.github.io/cheatsheets/strings/strings-cs.pdf
     type: cheatsheet

--- a/lessons/beginners/fstring/index.md
+++ b/lessons/beginners/fstring/index.md
@@ -1,6 +1,6 @@
 # Šablony (formátovací řetězce)
 
-Řekněme, že chceš vypsat určitou hodnotu uživatelovi s nějakou „omáčkou“ okolo.
+Řekněme, že chceš uživateli vypsat určitou hodnotu s nějakou „omáčkou“ okolo.
 Dá se na to použít `print()`, kterému můžeš předat „mix“ řetězců a čísel:
 
 ```pycon
@@ -56,7 +56,7 @@ Takovou šablonu můžeš použít jako *formátovací řetězec*
 (angl. [*formatted string literal*](https://docs.python.org/3.6/reference/lexical_analysis.html#formatted-string-literals),
 zkráceně *f-string*).
 Jako jakýkoli jiný řetězec ji vlož do uvozovek.
-A aby bylo jasné že jde o šablonu, před první uvozovky dej značku `f`.
+A aby bylo jasné, že jde o šablonu, před první uvozovky přidej navíc značku `f`.
 
 ```python
 f"Součet je {soucet}."

--- a/lessons/beginners/fstring/index.md
+++ b/lessons/beginners/fstring/index.md
@@ -94,3 +94,29 @@ A nakonec – v šabloně můžeš použít nejen jména proměnných, ale jak�
 Ale nepřežeň to!
 Většinou je program přehlednější, když si každou vypisovanou hodnotu zvlášť
 pojmenuješ – tedy uložíš do vhodně pojmenované proměnné.
+
+
+## Metoda format
+
+Někdy se stane, že jednu šablonu potřebuješ použít vícekrát.
+Pak formátovací řetězec použít nemůžeš, protože se do něj proměnné doplňují
+automaticky a hned.
+Pro takové případy existuje metoda `format`:
+
+```python
+sablona = 'Ahoj {jmeno}! Tvoje číslo {cislo}.'
+print(sablona.format(cislo=7, jmeno='Anežko'))
+print(sablona.format(cislo=42, jmeno='Elvíro'))
+print(sablona.format(cislo=3, jmeno='Viléme'))
+```
+
+Oproti formátovacím řetězcům umí `format` užitečnou zkratku: nepojmenované
+argumenty dosadí postupně do nepojmenovaných míst v šabloně:
+
+```python
+vypis = '{} krát {} je {}'.format(3, 4, 3 * 4)
+print(vypis)
+```
+
+Výrazy jako `f'Součet je {3 + 4}'` ale `format` dosadit neumí.
+Složitější dosazované hodnoty si proto vždycky pojmenuj.

--- a/lessons/beginners/fstring/index.md
+++ b/lessons/beginners/fstring/index.md
@@ -101,7 +101,8 @@ pojmenuješ – tedy uložíš do vhodně pojmenované proměnné.
 Někdy se stane, že jednu šablonu potřebuješ použít vícekrát.
 Pak formátovací řetězec použít nemůžeš, protože se do něj proměnné doplňují
 automaticky a hned.
-Pro takové případy existuje metoda `format`:
+V takovém případě můžeš šablonu napsat do normálního řetězce (bez `f` na
+začátku) a použít metodu `format`:
 
 ```python
 sablona = 'Ahoj {jmeno}! Tvoje číslo {cislo}.'

--- a/lessons/beginners/fstring/index.md
+++ b/lessons/beginners/fstring/index.md
@@ -1,0 +1,96 @@
+# Šablony (formátovací řetězce)
+
+Řekněme, že chceš vypsat určitou hodnotu uživatelovi s nějakou „omáčkou“ okolo.
+Dá se na to použít `print()`, kterému můžeš předat „mix“ řetězců a čísel:
+
+```pycon
+>>> soucet = 3 + 4
+>>> print('Součet je', soucet)
+```
+
+Co ale když chceš celý tento výpis uložit do proměnné – jako jeden řetězec?
+Čárka tu fungovat nebude, ta odděluje argumenty ve volání funkce.
+Je potřeba `soucet` převést na řetězec a ten pak připojit k „omáčce“:
+
+
+```pycon
+>>> hlaska = 'Součet je ' + str(soucet)
+```
+
+To ale není tak přehledné, jak by mohlo.
+Lze to zpřehlednit použitím šablony.
+
+Takovou šablonu si představ jako formulář s vynechanými místy:
+
+```plain
+Součet je __________.
+```
+
+Složitější šablona by byla třeba tahle:
+
+```plain
+Mil[ý/á] _______,
+Váš výsledek je __________.
+
+S pozdravem,
+_________
+```
+
+Aby Python věděl, do kterého vynechaného místa co doplnit, je potřeba
+jednotlivá vynechaná místa ve formuláři nějak jednoznačně označit.
+Použijme jména v „kudrnatých“ závorkách:
+
+```plain
+Součet je {soucet}.
+```
+
+```plain
+Mil{y_a} {osloveni},
+Váš výsledek je {soucet}.
+
+S pozdravem,
+{podpis}.
+```
+
+Takovou šablonu můžeš použít jako *formátovací řetězec*
+(angl. [*formatted string literal*](https://docs.python.org/3.6/reference/lexical_analysis.html#formatted-string-literals),
+zkráceně *f-string*).
+Jako jakýkoli jiný řetězec ji vlož do uvozovek.
+A aby bylo jasné že jde o šablonu, před první uvozovky dej značku `f`.
+
+```python
+f"Součet je {soucet}."
+```
+
+Takový formátovací řetězec jde použít v Pythonu – jako jakýkoli jiný řetězec:
+
+```python
+soucet = 3 + 4
+hlaska = f'Součet je {soucet}'
+print(hlaska)
+```
+
+```python
+y_a = 'á'
+osloveni = 'Anežko'
+soucet = 3 + 4
+podpis = 'Váš Program'
+
+print(f"""
+Mil{y_a} {osloveni},
+Váš výsledek je {soucet}.
+
+S pozdravem,
+{podpis}
+""")
+```
+
+A nakonec – v šabloně můžeš použít nejen jména proměnných, ale jakékoli výrazy.
+
+```pycon
+>>> hlaska = f'Součet je {3 + 4}'
+```
+
+Ale nepřežeň to!
+Většinou je program přehlednější, když si každou vypisovanou hodnotu zvlášť
+pojmenuješ – tedy uložíš do vhodně pojmenované proměnné.

--- a/lessons/beginners/fstring/info.yml
+++ b/lessons/beginners/fstring/info.yml
@@ -3,3 +3,4 @@ style: md
 attribution:
 - Pro PyLadies Brno napsal Petr Viktorin, 2018-2019.
 license: cc-by-sa-40
+license_code: cc0

--- a/lessons/beginners/fstring/info.yml
+++ b/lessons/beginners/fstring/info.yml
@@ -1,0 +1,5 @@
+title: Šablony (formátovací řetězce)
+style: md
+attribution:
+- Pro PyLadies Brno napsal Petr Viktorin, 2018-2019.
+license: cc-by-sa-40

--- a/lessons/beginners/str/index.md
+++ b/lessons/beginners/str/index.md
@@ -266,33 +266,6 @@ Všimni si, že `len` není metoda, ale funkce; píše se `len(r)`, ne `r.len()`
 Proč tomu tak je, to za nějakou dobu poznáš.
 
 
-## Formátování
-
-Obzvláště užitečná je metoda `format`,
-která v rámci řetězce nahradí dvojice „kudrnatých“ závorek
-za to, co dostane v argumentech:
-
-```python
-vypis = '{}×{} je {}'.format(3, 4, 3 * 4)
-print(vypis)
-```
-
-Řetězec `'{}×{} je {}'` tady funguje jako *šablona* (angl. *template*).
-Představ si to jako jako formulář, do kterého Python na vyznačená místa
-vpisuje hodnoty.
-
-Pokud chceš nahradit hodnoty v jiném pořadí, nebo když chceš aby šablona
-byla čitelnější, můžeš do „kudrnatých“ závorek napsat jména:
-
-```python
-vypis = 'Ahoj {jmeno}! Výsledek je {cislo}.'.format(cislo=7, jmeno='Elvíro')
-print(vypis)
-```
-
-Formátování se používá skoro všude, kde je
-potřeba „hezky“ vypsat nějakou hodnotu.
-
-
 ## Sekání řetězců
 
 Teď se vrátíme k vybírání kousků řetězců.


### PR DESCRIPTION
Here's my explanation on f-strings, improved over the last 3 "experimental" courses in Brno. I'm now pretty happy with it.
Also, I moved the text on `format` after it (with common explanations removed), because f-strings don't cover all the use cases.

Format specifications like `{number:08x}` and details like `'a[k]'.format(a)` are still left out.

Sadly, this didn't work-out time-wise wrt. https://github.com/PyLadiesCZ/naucse.python.cz/pull/48