### PR TITLE
Point materials from Hradec, Spring 2019 to an archived branch

### DIFF
--- a/runs/2019/pyladies-hradec-jaro/link.yml
+++ b/runs/2019/pyladies-hradec-jaro/link.yml
@@ -1,2 +1,2 @@
-repo: https://github.com/yiiva/naucse.python.cz.git
-branch: uhk-2019-03
+repo: https://github.com/pyvec/naucse.python.cz
+branch: archive/2019-pyladies-hradec-jaro

--- a/runs/2019/pyladies-hradec-jaro/link.yml
+++ b/runs/2019/pyladies-hradec-jaro/link.yml
@@ -1,2 +1,2 @@
 repo: https://github.com/pyvec/naucse.python.cz
-branch: archive/2019-pyladies-hradec-jaro
+branch: archive-2019-pyladies-hradec-jaro


### PR DESCRIPTION
The branch from `yiiva`'s repository was removed, breaking `naucse` builds.
I have reconstructed the branch's content; compared to the content currently on naucse it only contains extra typo fixes.

I plan to merge this soon to unblock building `naucse`.
A proposal to archive all historical runs in branches under the `pyvec` repo is discussed on Slack.