### PR TITLE
Use subpage subtitles for better breadcrumbs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ freeze = "python -m naucse freeze"
 
 [packages]
 naucse = ">=0.2"
-naucse-render = "<1.0"
+naucse-render = ">=1.3,<2.0"
 pygments-pytest = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d609e72b044d61b71a99c470d5761efdb5e051891cef7f4c5165da111096d793"
+            "sha256": "545c53bcfb847fe8507917d5ba72a4b0146f1d066361a05e04d9c3947ab681c4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -311,11 +311,10 @@
         },
         "naucse-render": {
             "hashes": [
-                "sha256:38730174ab499182a0a915c210060fceaa0be49ced88677e50865d6365ef9d34",
-                "sha256:66a36b29141d37398a2608e1f9718e850bc36908d1aae653531906b039b3ad58"
+                "sha256:6c564d7f9a7a56260da8638155dc3c64b171ce3ff92b57278c653507b1b96204"
             ],
             "index": "pypi",
-            "version": "==0.1"
+            "version": "==1.3"
         },
         "nbconvert": {
             "hashes": [

--- a/lessons/beginners/install-editor/info.yml
+++ b/lessons/beginners/install-editor/info.yml
@@ -4,14 +4,20 @@ attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017, Tomáš Roj (201
 license: cc-by-sa-40
 subpages:
     vscode:
-        title: Nastavení Visual Studio Code
+        title: Instalace Visual Studio Code
+        subtitle: Visual Studio Code
     atom:
-        title: Nastavení Atomu
+        title: Instalace Atomu
+        subtitle: Atom
     kate:
-        title: Nastavení Kate
+        title: Instalace Kate
+        subtitle: Kate
     gedit:
-        title: Nastavení Geditu
+        title: Instalace Geditu
+        subtitle: Gedit
     notepad-plus-plus:
-        title: Nastavení Notepadu++
+        title: Instalace Notepadu++
+        subtitle: Notepad++
     others:
         title: Nastavení editoru
+        subtitle: Nastavení

--- a/lessons/beginners/install-editor/vscode.md
+++ b/lessons/beginners/install-editor/vscode.md
@@ -1,7 +1,7 @@
 {% set editor_name = 'Visual Studio Code' %} {% set editor_url = 'https://code.visualstudio.com' %} 
 {% extends lesson.slug + '/_base.md' %}
 
-{% block name_gen %}Instalace Visual Studio Code{% endblock %}
+{% block name_gen %}Visual Studio Code{% endblock %}
 
 {% block install %}
 ## Stažení a instalace 

--- a/lessons/beginners/install/info.yml
+++ b/lessons/beginners/install/info.yml
@@ -4,8 +4,8 @@ attribution: Pro PyLadies Brno napsal Petr Viktorin, 2014-2017.
 license: cc-by-sa-40
 subpages:
     linux:
-        title: Instalace Pythonu - Linux
+        subtitle: Linux
     windows:
-        title: Instalace Pythonu - Windows
+        subtitle: Windows
     macos:
-        title: Instalace Pythonu - macOS
+        subtitle: macOS

--- a/lessons/intro/deployment/info.yml
+++ b/lessons/intro/deployment/info.yml
@@ -4,4 +4,4 @@ attribution: Pro kurz MI-PYT na ČVUT napsali Miro Hrončok, Petr Viktorin a dal
 license: cc-by-sa-40
 subpages:
     pythonanywhere:
-        title: Deployment webových aplikací na PythonAnywhere
+        subtitle: PythonAnywhere


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/302922/73196440-df122c80-412f-11ea-925b-0785cb94a6c4.png)
[After](https://naucse.python.cz/2020/brno-jaro-pondeli/beginners/install/linux/):
![image](https://user-images.githubusercontent.com/302922/73196552-15e84280-4130-11ea-8d7c-2b69512359f1.png)

This needs `naucse_render` 1.3.

Also, fix repeated "Instalace" in VSCode installation instructions.