### PR TITLE
Úprava příkladu .format

### DIFF
--- a/lessons/beginners/fstring/index.md
+++ b/lessons/beginners/fstring/index.md
@@ -105,10 +105,10 @@ V takovém případě můžeš šablonu napsat do normálního řetězce (bez `
 začátku) a použít metodu `format`:
 
 ```python
-sablona = 'Ahoj {jmeno}! Tvoje číslo {cislo}.'
-print(sablona.format(cislo=7, jmeno='Anežko'))
-print(sablona.format(cislo=42, jmeno='Elvíro'))
-print(sablona.format(cislo=3, jmeno='Viléme'))
+sablona = 'Ahoj {jmeno}! Tvoje číslo je {cislo}.'
+print(sablona.format(cislo=7, jmeno='Hynku'))
+print(sablona.format(cislo=42, jmeno='Viléme'))
+print(sablona.format(cislo=3, jmeno='Jarmilo'))
 ```
 
 Oproti formátovacím řetězcům umí `format` užitečnou zkratku: nepojmenované


### PR DESCRIPTION
- „Tvoje číslo je {cislo}.“ je smysluplná věta. Bez „je“ není.
- Tři příklady se jmény, navíc s jedním Vilémem, je naprosto promarněná příležitost. Navázáno na knižní tradici načatou veršem `"Naše staré hodiny\nbijí {2 + 2} hodiny."` a Werichovými vnuky a dědy.