### PR TITLE
git/install: Install git-gui on macOS

### DIFF
--- a/lessons/git/install/index.md
+++ b/lessons/git/install/index.md
@@ -73,7 +73,7 @@ Je-li už nainstalovaný, dozvíš se, jak ho používat
 Jinak ho nainstaluj pomocí Homebrew:
 
 ```console
-$ brew install git
+$ brew install git git-gui
 ```
 
 Nainstalovanému Gitu je ještě potřeba nastavit editor (zadej `nano`,


### PR DESCRIPTION
Homebrew has split the `git` and `git-gui` in January, see:
https://github.com/Homebrew/homebrew-core/commit/dfa3ccf1e7d3901e371b5140b935839ba9d8b706

Fixes: https://github.com/pyvec/naucse.python.cz/issues/646