### PR TITLE
Updated information about MI-PYT locations

### DIFF
--- a/courses/mi-pyt/info.yml
+++ b/courses/mi-pyt/info.yml
@@ -3,7 +3,7 @@ description: Základy již znáte a chcete se dozvědět o dalších možnostech
 long_description: |
     Díváte se na materiály předmětu MI-PYT (Pokročilý Python) na FIT ČVUT.
     Materiály jsou dostupné v dvojí podobě, interně pro studenty FITu
-    na *Eduxu* a pro všechny veřejně zde.
+    na *Course Pages* a pro všechny veřejně zde.
 
     Tento kurz vzniká pod záštitou firmy Red Hat Czech, s.r.o.
 


### PR DESCRIPTION
Edux is no longer used at FIT CTU and is replaced by [Course Pages](https://courses.fit.cvut.cz/).