### PR TITLE
Add missing rmdir example to command table in command line intro

### DIFF
--- a/lessons/beginners/cmdline/index.md
+++ b/lessons/beginners/cmdline/index.md
@@ -335,6 +335,12 @@ Tady je tabulka základních příkazů, se kterými si zatím vystačíme:
         <td><code>rm test.txt</code><br><code>del test.txt</code></td>
     </tr>
     <tr>
+        <td><code>rm -r</code></td>
+        <td><code>rmdir /S</code></td>
+        <td>smazání adresáře</td>
+        <td><code>rm -r test</code><br><code>rmdir /S test</code></td>
+    </tr>
+    <tr>
         <td><code>exit</code></td>
         <td><code>exit</code></td>
         <td>ukončení</td>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4539057/100242263-e8794a80-2f34-11eb-82bd-9ad1041906b0.png)

Fixes: https://github.com/pyvec/naucse.python.cz/issues/611