### PR TITLE
Definice 2022/pydata-praha-podzim

### DIFF
--- a/courses.yml
+++ b/courses.yml
@@ -411,6 +411,5 @@ lessons:
   path: tuesday-2022
   branch: compiled/beginners-tuesday-2022
 2022/pydata-praha-podzim:
-  url: https://github.com/PyDataCZ/naucse.python.cz
-  path: runs/2022/pydata-praha-podzim/
-  branch: praha-podzim2022
+  url: https://github.com/PyDataCZ/pyladies-kurz
+  branch: compiled

--- a/courses.yml
+++ b/courses.yml
@@ -411,5 +411,5 @@ lessons:
   path: tuesday-2022
   branch: compiled/beginners-tuesday-2022
 2022/pydata-praha-podzim:
-  url: https://github.com/PyDataCZ/pyladies-kurz
+  url: https://github.com/pydatacz/pyladies-kurz
   branch: compiled

--- a/courses.yml
+++ b/courses.yml
@@ -410,3 +410,7 @@ lessons:
   url: https://github.com/befeleme/naucse-python
   path: tuesday-2022
   branch: compiled/beginners-tuesday-2022
+2022/pydata-praha-podzim:
+  url: https://github.com/PyDataCZ/naucse.python.cz
+  path: runs/2022/pydata-praha-podzim/
+  branch: praha-podzim2022


### PR DESCRIPTION
Nejsem si jistý, že to je takto správně - zdá se že systém nauce se změnil. Pravděpodobně potřebujeme json definici runu (v https://github.com/PyDataCZ/naucse.python.cz/runs/2022/pydata-praha-podzim/) místo yaml ...