### PR TITLE
Add python beginners course in Ostrava 2022

### DIFF
--- a/courses.yml
+++ b/courses.yml
@@ -423,3 +423,7 @@ lessons:
 2022/plzen-podzim-2022:
   branch: compiled
   url: https://github.com/pyladies-pilsen/naucse-python
+2022/ostrava-python:
+  url: https://github.com/petracihalova/naucse-python
+  path: ostrava2022_python
+  branch: compiled/ostrava2022_python


### PR DESCRIPTION
This adds first version of python beginners course in Ostrava 2022 (starts 12. 10. 2022). My plan is to add rest of lessons later. 