### PR TITLE
Remove link to plzen-podzim-2022.

### DIFF
--- a/courses.yml
+++ b/courses.yml
@@ -420,9 +420,6 @@ lessons:
 2022/brno-mergado:
   branch: compiled
   url: https://github.com/milandufek/naucse-python
-2022/plzen-podzim-2022:
-  branch: compiled
-  url: https://github.com/pyladies-pilsen/naucse-python
 2022/ostrava-python:
   url: https://github.com/petracihalova/naucse-python
   path: ostrava2022_python


### PR DESCRIPTION
The link points to the compiled branch causing duplicity, we do not need the old course materials. Cen we just remove it and solve having more courses in one repo later i.e. for another course?