### PR TITLE
Archive old courses

### DIFF
--- a/courses.yml
+++ b/courses.yml
@@ -379,8 +379,9 @@ lessons:
   path: 2021/pyladies-praha-jaro2021
   url: https://github.com/naucse/archived-courses
 2021/linuxadmin-podzim:
-  branch: compiled
-  url: https://github.com/encukou/linuxadmin
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2021/linuxadmin-podzim
 2021/plzen-podzim-2021:
   branch: main
   path: 2021/plzen-podzim-2021
@@ -390,8 +391,9 @@ lessons:
   path: 2021/pydata-praha-podzim
   url: https://github.com/naucse/archived-courses
 2021/pyladies-olomouc-podzim:
-  branch: compiled/autumn2021-olomouc
-  url: https://github.com/pyladiescz/naucse.python.cz
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2021/pyladies-olomouc-podzim
 2021/pyladies-ostrava-podzim:
   branch: main
   path: 2021/pyladies-ostrava-podzim
@@ -401,60 +403,68 @@ lessons:
   path: 2021/pyladies-praha-podzim2021
   url: https://github.com/naucse/archived-courses
 2022/plzen-jaro-2022:
-  url: https://github.com/pyladies-pilsen/naucse.python.cz
-  branch: compiled/pilsen_spring_2022
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2022/plzen-jaro-2022
 2022/snake-brno-podzim:
-  url: https://github.com/encukou/naucse-python
-  branch: compiled/snake-2022
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2022/snake-brno-podzim
 2022/brno-podzim-utery:
-  url: https://github.com/befeleme/naucse-python
-  path: tuesday-2022
-  branch: compiled/beginners-tuesday-2022
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2022/brno-podzim-utery
 2022/pydata-praha-podzim:
-  url: https://github.com/pydatacz/pyladies-kurz
-  branch: compiled
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2022/pydata-praha-podzim
 2022/praha-pyladies-podzim:
-  branch: compiled-pyladies-praha-podzim2022
-  url: https://github.com/brabemi/naucse-python
-  path: pyladies
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2022/praha-pyladies-podzim
 2022/brno-mergado:
-  branch: compiled
-  url: https://github.com/milandufek/naucse-python
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2022/brno-mergado
 2022/plzen-podzim-2022:
   branch: compiled
   url: https://github.com/pyladies-pilsen/naucse-python
 2022/ostrava-python:
-  url: https://github.com/petracihalova/naucse-python
-  path: ostrava2022_python
-  branch: compiled/ostrava2022_python
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2022/ostrava-python
 2022/pilsen-sitport-python:
-  url: https://github.com/zitkat/lite-python-kurz
-  branch: compiled
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2022/pilsen-sitport-python
 2023/praha-pyladies-jaro:
-  branch: compiled-pyladies-praha-jaro2023
-  url: https://github.com/brabemi/naucse-python
-  path: pyladies
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2023/praha-pyladies-jaro
 2023/brno-micropython:
-  branch: compiled/mp2023
-  url: https://github.com/encukou/naucse-micropython
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2023/brno-micropython
 2023/brno-jaro-ctvrtek:
-  url: https://github.com/befeleme/naucse-python
-  path: thursday-2023
-  branch: compiled/beginners-thursday-2023
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2023/brno-jaro-ctvrtek
 2023/snake-europython:
-  url: https://github.com/encukou/snake-workshop
-  branch: compiled/snake-ep-2023
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2023/snake-europython
 2023/praha-pyladies-podzim:
-  branch: compiled-pyladies-praha-podzim2023
-  url: https://github.com/brabemi/naucse-python
-  path: pyladies
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2023/praha-pyladies-podzim
 2023/brno-podzim-streda:
-  url: https://github.com/ZelenyMartin/naucse-python
-  path: 2023-brno-podzim-streda
-  branch: compiled/2023-brno-podzim-streda
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2023/brno-podzim-streda
 2023/pydata-praha-podzim:
-  url: https://github.com/PyDataCZ/pyladies-kurz
-  branch: compiled2023
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2023/pydata-praha-podzim
 2024/plzen-jaro-2024:
   branch: compiled
   url: https://github.com/pyladies-pilsen/naucse-python

--- a/courses.yml
+++ b/courses.yml
@@ -427,8 +427,9 @@ lessons:
   branch: main
   path: 2022/brno-mergado
 2022/plzen-podzim-2022:
-  branch: compiled
-  url: https://github.com/pyladies-pilsen/naucse-python
+  url: https://github.com/naucse/archived-courses
+  branch: main
+  path: 2022/plzen-podzim-2022
 2022/ostrava-python:
   url: https://github.com/naucse/archived-courses
   branch: main


### PR DESCRIPTION
Use the `archived-courses` repo for older courses. This will preserve data if the original repo is removed, and speeds up the build as there's less fetching.

Thanks @zitkat for the push in #747 :)