### PR TITLE
Update courses definition for new branch name

### DIFF
--- a/courses.yml
+++ b/courses.yml
@@ -1,22 +1,22 @@
 courses/pyladies:
-  branch: compiled
+  branch: compiled/main
   path: pyladies
   url: https://github.com/pyvec/naucse-python
   canonical: true
   featured: 1
 courses/mi-pyt:
-  branch: compiled
+  branch: compiled/main
   path: mi-pyt
   url: https://github.com/pyvec/naucse-python
   canonical: true
   featured: 2
 courses/meta:
-  branch: compiled
+  branch: compiled/main
   path: meta
   url: https://github.com/pyvec/naucse-python
   canonical: true
 lessons:
-  branch: compiled
+  branch: compiled_archive
   path: lessons
   url: https://github.com/pyvec/naucse-python
   canonical: true


### PR DESCRIPTION
These changes are needed after https://github.com/pyvec/naucse-python/pull/43

This means [`lessons`](https://naucse.python.cz/lessons/) will no longer be updated. When I get more time for naucse, I'd like to remove that anyway (redirect the existing ones to other pages).
